### PR TITLE
Update module to disallow public ACL and public policy setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Creates a private S3 bucket with good defaults:
 The following policy rules are set:
 
 * Deny uploading public objects.
+* Deny updating policy to allow public objects.
+
+The following ACL rules are set:
+
+* Retroactively remove public access granted through public ACLs
+* Deny updating ACL to public
 
 The following lifecycle rules are set:
 
@@ -29,14 +35,13 @@ The following lifecycle rules are set:
       }
     }
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | bucket | The name of the bucket. It will be prefixed with the AWS account alias. | string | - | yes |
-| custom_bucket_policy | JSON formatted bucket policy to attach to the bucket. | string | `` | no |
-| logging_bucket | The S3 bucket to send S3 access logs. | string | - | yes |
+| custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | string | `` | no |
+| logging\_bucket | The S3 bucket to send S3 access logs. | string | - | yes |
 | tags | A mapping of tags to assign to the bucket. | map | `<map>` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -12,10 +12,10 @@
  * * Deny updating policy to allow public objects.
  *
  * The following ACL rules are set:
- * 
+ *
  * * Retroactively remove public access granted through public ACLs
  * * Deny updating ACL to public
- * 
+ *
  * The following lifecycle rules are set:
  *
  * * Incomplete multipart uploads are deleted after 14 days.
@@ -89,12 +89,14 @@ resource "aws_s3_bucket_public_access_block" "public_access_block" {
   bucket = "${aws_s3_bucket.private_bucket.id}"
 
   # Block new public ACLs and uploading public objects
-  block_public_acls   = true
-  # Retroactively remove public access granted through public ACLs 
+  block_public_acls = true
+
+  # Retroactively remove public access granted through public ACLs
   ignore_public_acls = true
-  # Block new public bucket policies 
+
+  # Block new public bucket policies
   block_public_policy = true
+
   # Retroactivley block public and cross-account access if bucket has public policies
   restrict_public_buckets = true
-
 }


### PR DESCRIPTION
Currently, the module at version 1.5.0 creates a bucket that is "... not public but anyone with appropriate permissions can grant public access to objects." 

i.e. - 
![screen shot 2019-01-16 at 2 22 24 pm](https://user-images.githubusercontent.com/8170735/51282600-5ac48f80-199a-11e9-8c31-d63b888269d3.png)


This PR implements terraform's public access block module (https://www.terraform.io/docs/providers/aws/r/s3_bucket_public_access_block.html), so that the bucket is set to "bucket and objects do not have any public access.". This will apply retroactive changes to existing buckets depending on this module, in that the ACL and policies will be set to "private" and disallow future changing to public.
![screen shot 2019-01-16 at 2 24 29 pm](https://user-images.githubusercontent.com/8170735/51282629-76c83100-199a-11e9-9615-9325d458257d.png)


