### PR TITLE
Make account alias prefix optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,8 @@
 data "aws_iam_account_alias" "current" {}
 
 locals {
-  bucket_id = "${data.aws_iam_account_alias.current.account_alias}-${var.bucket}"
+  bucket_prefix = "${var.use_account_alias_prefix ? format("%s-", data.aws_iam_account_alias.current.account_alias) : ""}"
+  bucket_id     = "${local.bucket_prefix}${var.bucket}"
 }
 
 resource "aws_s3_bucket" "private_bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,12 @@
 variable "bucket" {
-  description = "The name of the bucket. It will be prefixed with the AWS account alias."
+  description = "The name of the bucket."
   type        = "string"
+}
+
+variable "use_account_alias_prefix" {
+  description = "Whether to prefix the bucket name with the AWS account alias."
+  type        = "string"
+  default     = true
 }
 
 variable "custom_bucket_policy" {


### PR DESCRIPTION
There are a variety of times when we don't want the account alias to prefix the bucket name:

* existing project using a different prefix scheme
* using cross-account aliases where the bucket will live in a different account than the user running terraform

This adds an option to disable the account alias prefixing.

The minor version will be bumped when this lands.