### PR TITLE
Output the bucket domain variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The following lifecycle rules are set:
 | Name | Description |
 |------|-------------|
 | arn | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
+| bucket\_domain\_name | The bucket domain name. |
+| bucket\_regional\_domain\_name | The bucket region-specific domain name. |
 | id | The name of the bucket. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,13 @@ output "arn" {
   description = "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname."
   value       = "${aws_s3_bucket.private_bucket.arn}"
 }
+
+output "bucket_domain_name" {
+  description = "The bucket domain name."
+  value       = "${aws_s3_bucket.private_bucket.bucket_domain_name}"
+}
+
+output "bucket_regional_domain_name" {
+  description = "The bucket region-specific domain name."
+  value       = "${aws_s3_bucket.private_bucket.bucket_regional_domain_name}"
+}


### PR DESCRIPTION
I'd like to be able to access these two variables from the private bucket for use in a cloudfront distribution. 