### PR TITLE
add dependabot for go modules, golangci-lint in precommit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
       - run:
           name: Run pre-commit tests
           command: pre-commit run --all-files
+      - run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+version: 1
+update_configs:
+  # Keep go modules up to date, batching pull requests weekly
+  - package_manager: "go:modules"
+    directory: "/"
+    update_schedule: "weekly"
+    # Apply default reviewer @trussworks/waddlers group to PRs
+    default_reviewers:
+      - "trussworks/waddlers"
+    # Apply dependencies label to PRs
+    default_labels:
+      - "dependencies"
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         - --autofix
     -   id: trailing-whitespace
 
- - repo: git://github.com/golangci/golangci-lint
+-   repo: git://github.com/golangci/golangci-lint
     rev: v1.21.0
     hooks:
       - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,13 @@ repos:
         - --autofix
     -   id: trailing-whitespace
 
+ - repo: git://github.com/golangci/golangci-lint
+    rev: v1.21.0
+    hooks:
+      - id: golangci-lint
+        entry: golangci-lint run --verbose
+        verbose: true
+
 -   repo: git://github.com/antonbabenko/pre-commit-terraform
     rev: v1.10.0
     hooks:


### PR DESCRIPTION
Addresses: https://www.pivotaltracker.com/story/show/169136125

Add golangci-lint to pre-commit -- https://github.com/golangci/golangci-lint
Add a dependabot config for go modules to be updated weekly.

Have given dependabot access to this repo.

please 👀 and let me know if you want me to name the golint step in the precommit yaml!