### PR TITLE
Update go module cache path for terratest jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v1-{{ checksum "go.sum" }}
       - run:
           name: Run terratest
           command: go test -v ./test/...
       - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          key: go-mod-sources-v1-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg/mod"
+            - "~/go/pkg/mod"
 
   terratest-tf12:
     docker:
@@ -45,14 +45,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v1-{{ checksum "go.sum" }}
       - run:
           name: Run terratest
           command: go test -v ./test/...
       - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          key: go-mod-sources-v1-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg/mod"
+            - "~/go/pkg/mod"
 
 workflows:
   version: 2

--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -164,13 +164,11 @@ func isTerraformVersion(t *testing.T, version string) (bool, error) {
 	cmd := exec.Command("terraform", "version")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.Log(t, err)
 		return false, err
 	}
 
 	matched, err := regexp.Match(fmt.Sprintf("Terraform v%s", version), out)
 	if err != nil {
-		logger.Log(t, err)
 		return false, err
 	}
 	return matched, nil


### PR DESCRIPTION
Per https://www.pivotaltracker.com/story/show/169242580, fix the go module cache path for the terratest CircleCI jobs.