### PR TITLE
Add retries to terratests

### DIFF
--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -38,7 +38,7 @@ func GetPublicAccessBlockConfigurationE(t *testing.T, region string, bucketName 
 
 	var publicAccessBlockConfiguration *s3.PublicAccessBlockConfiguration
 	maxRetries := 3
-	retryDuration, _ := time.ParseDuration("5s")
+	retryDuration, _ := time.ParseDuration("30s")
 	_, err = retry.DoWithRetryE(t, "Get public access block configuration", maxRetries, retryDuration,
 		func() (string, error) {
 			publicAccessBlock, err := s3Client.GetPublicAccessBlock(params)
@@ -74,7 +74,7 @@ func AssertS3BucketEncryptionEnabledE(t *testing.T, region string, bucketName st
 	}
 
 	maxRetries := 3
-	retryDuration, _ := time.ParseDuration("5s")
+	retryDuration, _ := time.ParseDuration("30s")
 	_, err = retry.DoWithRetryE(t, "Get bucket encryption", maxRetries, retryDuration, func() (string, error) {
 
 		encryption, err := s3Client.GetBucketEncryption(params)

--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -75,24 +75,24 @@ func AssertS3BucketEncryptionEnabledE(t *testing.T, region string, bucketName st
 
 	maxRetries := 3
 	retryDuration, _ := time.ParseDuration("30s")
-	_, err = retry.DoWithRetryE(t, "Get bucket encryption", maxRetries, retryDuration, func() (string, error) {
+	_, err = retry.DoWithRetryE(t, "Get bucket encryption", maxRetries, retryDuration,
+		func() (string, error) {
+			encryption, err := s3Client.GetBucketEncryption(params)
 
-		encryption, err := s3Client.GetBucketEncryption(params)
-
-		if err != nil {
-			return "", err
-		}
-
-		expectedEncryption := "AES256"
-		for _, element := range encryption.ServerSideEncryptionConfiguration.Rules {
-			actualEncryption := element.ApplyServerSideEncryptionByDefault.SSEAlgorithm
-			if *actualEncryption != expectedEncryption {
-				return "", fmt.Errorf("server side encyption test failed. got: %v, expected: %v", actualEncryption, expectedEncryption)
+			if err != nil {
+				return "", err
 			}
-		}
 
-		return "Retrieved bucket encryption", nil
-	},
+			expectedEncryption := "AES256"
+			for _, element := range encryption.ServerSideEncryptionConfiguration.Rules {
+				actualEncryption := element.ApplyServerSideEncryptionByDefault.SSEAlgorithm
+				if *actualEncryption != expectedEncryption {
+					return "", fmt.Errorf("server side encyption test failed. got: %v, expected: %v", actualEncryption, expectedEncryption)
+				}
+			}
+
+			return "Retrieved bucket encryption", nil
+		},
 	)
 
 	return err


### PR DESCRIPTION
Per https://www.pivotaltracker.com/story/show/169267652, add retry logic to the terratests. We noticed that certain terratests (s3 public access block configuration or bucket encryption) would sporadically fail, but then would succeed when rerunning the test. The errors are most likely due to eventual consistency issues, where the s3 bucket configurations have not fully propagated by the time the terratests are run. This PR attempts to address that issue by leveraging Terratest's retry module.