### PR TITLE
Fixes to support terraform-docs 0.8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 references:
-  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:tf12-fc7b4b9561a166e9039dc3fdf3a8ce3b734c815c
+  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:40076395a6e6a349f92caa92c4de614e105fe672
 
 jobs:
   validate:

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  "no-inline-html": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,17 +12,17 @@ repos:
     -   id: trailing-whitespace
 
 -   repo: git://github.com/golangci/golangci-lint
-    rev: v1.21.0
+    rev: v1.23.1
     hooks:
       - id: golangci-lint
 
 -   repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.21.0
+    rev: v1.24.0
     hooks:
     - id: terraform_docs
     - id: terraform_fmt
 
 -   repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.21.0
     hooks:
     -   id: markdownlint

--- a/README.md
+++ b/README.md
@@ -44,18 +44,24 @@ module "aws-s3-bucket" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| bucket | The name of the bucket. | string | n/a | yes |
-| custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | string | `""` | no |
-| enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | bool | `"false"` | no |
-| inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | string | `"ORC"` | no |
-| logging\_bucket | The S3 bucket to send S3 access logs. | string | `""` | no |
-| schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | string | `"Weekly"` | no |
-| tags | A mapping of tags to assign to the bucket. | map(string) | `{}` | no |
-| use\_account\_alias\_prefix | Whether to prefix the bucket name with the AWS account alias. | string | `"true"` | no |
+|------|-------------|------|---------|:-----:|
+| bucket | The name of the bucket. | `string` | n/a | yes |
+| custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
+| enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
+| inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
+| logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
+| schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
+| tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+| use\_account\_alias\_prefix | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |
 
 ## Outputs
 


### PR DESCRIPTION
terraform-docs 0.8 will dump some inline HTML in the readme for object variable, so I've removed the rule from the markdownlint config.