### PR TITLE
require aws provider version be >= 2.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ module "aws-s3-bucket" {
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 2.37.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = ">= 2.37.0"
+  }
 }


### PR DESCRIPTION
It looks like the `IntelligentTieringAccessTier` option for bucket inventory was only added in 2.37.0, so this PR sets a required version on 2.37.0

See https://github.com/terraform-providers/terraform-provider-aws/issues/10743