### PR TITLE
Setting default bucket policy to enforce TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,6 @@ module "aws-s3-bucket" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12 |
-| aws | >= 2.37.0 |
-
 ## Providers
 
 | Name | Version |
@@ -60,7 +53,7 @@ module "aws-s3-bucket" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+|------|-------------|------|---------|:-----:|
 | bucket | The name of the bucket. | `string` | n/a | yes |
 | custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ module "aws-s3-bucket" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.37.0 |
+
 ## Providers
 
 | Name | Version |
@@ -53,7 +60,7 @@ module "aws-s3-bucket" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | bucket | The name of the bucket. | `string` | n/a | yes |
 | custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -35,9 +35,10 @@ data "aws_iam_policy_document" "enforcetls" {
   }
 }
 
-resource "aws_s3_bucket_policy" "my_bucket_policy" {
-  bucket = aws_s3_bucket.private_bucket.id
-  policy = data.aws_iam_policy_document.enforcetls.json
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  depends_on = [aws_s3_bucket_public_access_block.public_access_block]
+  bucket     = aws_s3_bucket.private_bucket.id
+  policy     = data.aws_iam_policy_document.enforcetls.json
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
 # We do this by extending the custom_bucket_policy
 #
 
-data "aws_iam_policy_document" "enforcetls" {
+data "aws_iam_policy_document" "enforce_tls" {
 
   source_json = var.custom_bucket_policy
 
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "enforcetls" {
 resource "aws_s3_bucket_policy" "bucket_policy" {
   depends_on = [aws_s3_bucket_public_access_block.public_access_block]
   bucket     = aws_s3_bucket.private_bucket.id
-  policy     = data.aws_iam_policy_document.enforcetls.json
+  policy     = data.aws_iam_policy_document.enforce_tls.json
 }
 
 


### PR DESCRIPTION
This PR adds a default bucket policy to deny SSL/TLS on object transmission. This addresses the AWS Config `s3-bucket-ssl-requests-only` requirements.

Note if a user provides a bucket policy they still need to add the deny themselves.