### PR TITLE
add storage class analytics & corresponding bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,26 @@
 version: 2
 
 references:
-  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:3d70af4b3491a7b773ae36ddfc6a1acf71cd92d2
+  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:c542b22c7fb95db0a1bbe043928a457ae6fbeaca
 
 jobs:
-  validate:
+  terratest:
     docker:
       - image: *circleci_docker_primary
+        environment:
+        - TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+            - go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version" }}
       - run:
-          name: Run pre-commit tests
-          command: make pre_commit_tests
-      - save_cache:
-          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-          paths:
-            - ~/.cache
-
-  terratest:
-    docker:
-      - image: *circleci_docker_primary
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-sources-v1-{{ checksum "go.sum" }}
+          name: Adding go binaries to $PATH
+          command: |
+            echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
+            source $BASH_ENV
+      - run: go get github.com/jstemmer/go-junit-report
       - run:
           name: Assume role and run terratest
           command: |
@@ -39,13 +32,18 @@ jobs:
             export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
             make test
       - save_cache:
-          key: go-mod-sources-v1-{{ checksum "go.sum" }}
+          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+          paths:
+            - ~/.cache
+      - save_cache:
+          key: go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version" }}
           paths:
             - "~/go/pkg/mod"
+      - store_test_results:
+          path: /tmp/test-results/gotest
 
 workflows:
   version: 2
   validate:
     jobs:
-      - validate
       - terratest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 references:
-  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:8122ec14fdda6e5f18457385e4c70351c2d54523
+  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:3d70af4b3491a7b773ae36ddfc6a1acf71cd92d2
 
 jobs:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,38 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
-    hooks:
-    -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-yaml
-    -   id: detect-private-key
-    -   id: pretty-format-json
-        args:
-        - --autofix
-    -   id: trailing-whitespace
+    -   repo: local
+        hooks:
+        -   id: go-version
+            name: go version
+            entry: bin/check-go-version
+            language: script
+            types: [go]
 
--   repo: git://github.com/golangci/golangci-lint
-    rev: v1.24.0
-    hooks:
-      - id: golangci-lint
+    -   repo: git://github.com/pre-commit/pre-commit-hooks
+        rev: v2.5.0
+        hooks:
+        -   id: check-json
+        -   id: check-merge-conflict
+        -   id: check-yaml
+        -   id: detect-private-key
+        -   id: pretty-format-json
+            args:
+            - --autofix
+        -   id: trailing-whitespace
 
--   repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.29.0
-    hooks:
-    - id: terraform_docs
-    - id: terraform_fmt
+    -   repo: git://github.com/golangci/golangci-lint
+        rev: v1.24.0
+        hooks:
+          - id: golangci-lint
+            entry: golangci-lint run --verbose
+            verbose: true
 
--   repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
-    hooks:
-    -   id: markdownlint
+    -   repo: git://github.com/antonbabenko/pre-commit-terraform
+        rev: v1.29.0
+        hooks:
+        - id: terraform_docs
+        - id: terraform_fmt
+
+    -   repo: git://github.com/igorshubovych/markdownlint-cli
+        rev: v0.22.0
+        hooks:
+        -   id: markdownlint

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ pre_commit_tests: ensure_pre_commit ## Run pre-commit tests
 
 .PHONY: test
 test: pre_commit_tests
-	go test -count 1 -v -timeout 90m ./test/...
+	bin/make-test
 
 .PHONY: clean
 clean:
 	rm -f .*.stamp
+	rm -f bin

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ module "aws-s3-bucket" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| analytics\_bucket | The ARN of the analytics bucket. Leave blank to disable. | `string` | `""` | no |
 | bucket | The name of the bucket. | `string` | n/a | yes |
 | custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |

--- a/bin/check-go-version
+++ b/bin/check-go-version
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+set -eu -o pipefail
+
+VERSION="go1.14"
+
+GOLANG_VERSION=$(go version)
+if [[ $GOLANG_VERSION = *$VERSION* ]]; then
+  echo "Golang $GOLANG_VERSION installed"
+else
+  echo "Golang $VERSION is required to run this project! Found $GOLANG_VERSION"
+  echo "Install go with 'brew install go'"
+  echo "or if that version is ahead of ${GOLANG_VERSION} then run:"
+  echo "Run 'brew install go@1.14 && brew link --force go@1.14' to install"
+  exit 1
+fi

--- a/bin/make-test
+++ b/bin/make-test
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+go_test_output="/tmp/go-test.out"
+
+go test -short -count 1 -v -timeout 90m github.com/trussworks/terraform-aws-s3-private-bucket/test/... | tee "${go_test_output}"
+
+# Check if we are running tests inside of CircleCI by checking for a $CIRCLECI
+# environment variable. The dash after $CIRCLECI substitutes a null value if
+# CIRCLECI is unset. This prevents unbound variable errors
+if [[ -n ${CIRCLECI-} ]]; then
+    mkdir -p "${TEST_RESULTS}"/gotest
+    go-junit-report < "${go_test_output}" \
+                    > "${TEST_RESULTS}/gotest/go-test-report.xml"
+fi

--- a/examples/simple-no-analytics/main.tf
+++ b/examples/simple-no-analytics/main.tf
@@ -1,0 +1,10 @@
+#
+# Private Bucket
+#
+
+module "s3_private_bucket" {
+  source = "../../"
+
+  bucket                   = var.test_name
+  use_account_alias_prefix = false
+}

--- a/examples/simple-no-analytics/variables.tf
+++ b/examples/simple-no-analytics/variables.tf
@@ -1,0 +1,7 @@
+variable "test_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}

--- a/main.tf
+++ b/main.tf
@@ -130,3 +130,20 @@ resource "aws_s3_bucket_inventory" "inventory" {
   optional_fields = ["Size", "LastModifiedDate", "StorageClass", "ETag", "IsMultipartUploaded", "ReplicationStatus", "EncryptionStatus",
   "ObjectLockRetainUntilDate", "ObjectLockMode", "ObjectLockLegalHoldStatus", "IntelligentTieringAccessTier"]
 }
+
+resource "aws_s3_bucket_analytics_configuration" "analytics" {
+  count  = var.analytics_bucket != "" ? 1 : 0
+  bucket = aws_s3_bucket.private_bucket.id
+  name   = "BucketAnalytics"
+
+  storage_class_analysis {
+    data_export {
+      destination {
+        s3_bucket_destination {
+          bucket_arn = var.analytics_bucket
+          prefix     = "s3-analytics/${local.bucket_id}/"
+        }
+      }
+    }
+  }
+}

--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -405,14 +405,14 @@ func AssertS3BucketAnalyticsNotEnabledE(t *testing.T, region string, bucketName 
 	return nil
 }
 
-func TestTerraformAwsS3PrivateBucketNoLoggingNoAnalytics(t *testing.T) {
+func TestTerraformAwsS3PrivateBucketNoAnalytics(t *testing.T) {
 	t.Parallel()
 
-	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple-no-logging")
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple-no-analytics")
 
 	// Give this S3 Bucket a unique ID for a name tag so we can distinguish it from any other Buckets provisioned
 	// in your AWS account
-	testName := fmt.Sprintf("terratest-aws-s3-private-bucket-no-logging-no-analytics-%s", strings.ToLower(random.UniqueId()))
+	testName := fmt.Sprintf("terratest-aws-s3-private-bucket-no-analytics-%s", strings.ToLower(random.UniqueId()))
 	awsRegion := "us-west-2"
 
 	terraformOptions := &terraform.Options{
@@ -444,6 +444,5 @@ func TestTerraformAwsS3PrivateBucketNoLoggingNoAnalytics(t *testing.T) {
 	terraform.InitAndApply(t, terraformOptions)
 
 	AssertS3BucketAnalyticsNotEnabled(t, awsRegion, testName)
-	AssertS3BucketLoggingNotEnabled(t, awsRegion, testName)
 	AssertS3BucketPolicyContainsNonTLSDeny(t, awsRegion, testName)
 }

--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -373,3 +373,77 @@ func TestTerraformAwsS3PrivateBucketNoLoggingBucket(t *testing.T) {
 	AssertS3BucketLoggingNotEnabled(t, awsRegion, testName)
 	AssertS3BucketPolicyContainsNonTLSDeny(t, awsRegion, testName)
 }
+
+func AssertS3BucketAnalyticsNotEnabled(t *testing.T, region string, bucketName string) {
+	err := AssertS3BucketAnalyticsNotEnabledE(t, region, bucketName)
+	require.NoError(t, err)
+}
+
+func AssertS3BucketAnalyticsNotEnabledE(t *testing.T, region string, bucketName string) error {
+	s3client, err := aws.NewS3ClientE(t, region)
+
+	if err != nil {
+		return err
+	}
+
+	params := &s3.GetBucketAnalyticsConfigurationInput{
+		Bucket: awssdk.String(bucketName),
+	}
+
+	bucketAnalytics, err := s3client.GetBucketAnalyticsConfiguration(params)
+
+	if err != nil {
+		return err
+	}
+
+	analyticsEnabled := bucketAnalytics.AnalyticsConfiguration
+
+	if analyticsEnabled == nil {
+		return fmt.Errorf("Analytics is not enabled")
+	}
+
+	return nil
+}
+
+func TestTerraformAwsS3PrivateBucketNoLoggingNoAnalytics(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple-no-logging")
+
+	// Give this S3 Bucket a unique ID for a name tag so we can distinguish it from any other Buckets provisioned
+	// in your AWS account
+	testName := fmt.Sprintf("terratest-aws-s3-private-bucket-no-logging-no-analytics-%s", strings.ToLower(random.UniqueId()))
+	awsRegion := "us-west-2"
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: tempTestFolder,
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"test_name": testName,
+			"region":    awsRegion,
+		},
+
+		// Environment variables to set when running Terraform
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	aws.AssertS3BucketExists(t, awsRegion, testName)
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	AssertS3BucketAnalyticsNotEnabled(t, awsRegion, testName)
+	AssertS3BucketLoggingNotEnabled(t, awsRegion, testName)
+	AssertS3BucketPolicyContainsNonTLSDeny(t, awsRegion, testName)
+}

--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -386,20 +386,20 @@ func AssertS3BucketAnalyticsNotEnabledE(t *testing.T, region string, bucketName 
 		return err
 	}
 
-	params := &s3.GetBucketAnalyticsConfigurationInput{
+	params := &s3.ListBucketAnalyticsConfigurationsInput{
 		Bucket: awssdk.String(bucketName),
 	}
 
-	bucketAnalytics, err := s3client.GetBucketAnalyticsConfiguration(params)
+	bucketAnalytics, err := s3client.ListBucketAnalyticsConfigurations(params)
 
 	if err != nil {
 		return err
 	}
 
-	analyticsEnabled := bucketAnalytics.AnalyticsConfiguration
+	analytics := bucketAnalytics.AnalyticsConfigurationList
 
-	if analyticsEnabled == nil {
-		return fmt.Errorf("Analytics is not enabled")
+	if len(analytics) != 0 {
+		return fmt.Errorf("Analytics is enabled")
 	}
 
 	return nil

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,9 @@ variable "schedule_frequency" {
   default     = "Weekly"
   description = "The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'."
 }
+
+variable "analytics_bucket" {
+  type        = string
+  default     = ""
+  description = "The ARN of the analytics bucket. Leave blank to disable."
+}


### PR DESCRIPTION
# [Tracker story](https://www.pivotaltracker.com/story/show/169298624)

Now that the kinks are worked out, let's start fresh. 

Changes proposed in this pull request:

-  Adds `aws_s3_bucket_analytics_configuration` resource block to root `main.tf` & analytics variable to `variables.tf`
- Adds appropriate terratests for the above configuration

Opened in favor of the now-closed #95 , a PR in which I did too much repo cleanup unrelated to the ticket's AC (cue  _Doin Too Much_ by Kash Doll) & made a mockery of proper terratesting
