### PR TITLE
Fix weirdness in golangci hook which forces file duplication within terratest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,26 @@
 version: 2
 
 references:
-  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:8122ec14fdda6e5f18457385e4c70351c2d54523
+  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:c542b22c7fb95db0a1bbe043928a457ae6fbeaca
 
 jobs:
-  validate:
+  terratest:
     docker:
       - image: *circleci_docker_primary
+        environment:
+        - TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+            - go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version" }}
       - run:
-          name: Run pre-commit tests
-          command: make pre_commit_tests
-      - save_cache:
-          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-          paths:
-            - ~/.cache
-
-  terratest:
-    docker:
-      - image: *circleci_docker_primary
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-sources-v1-{{ checksum "go.sum" }}
+          name: Adding go binaries to $PATH
+          command: |
+            echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
+            source $BASH_ENV
+      - run: go get github.com/jstemmer/go-junit-report
       - run:
           name: Assume role and run terratest
           command: |
@@ -39,13 +32,18 @@ jobs:
             export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
             make test
       - save_cache:
-          key: go-mod-sources-v1-{{ checksum "go.sum" }}
+          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+          paths:
+            - ~/.cache
+      - save_cache:
+          key: go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version" }}
           paths:
             - "~/go/pkg/mod"
+      - store_test_results:
+          path: /tmp/test-results/gotest
 
 workflows:
   version: 2
   validate:
     jobs:
-      - validate
       - terratest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,38 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
-    hooks:
-    -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-yaml
-    -   id: detect-private-key
-    -   id: pretty-format-json
-        args:
-        - --autofix
-    -   id: trailing-whitespace
+    -   repo: local
+        hooks:
+        -   id: go-version
+            name: go version
+            entry: bin/check-go-version
+            language: script
+            types: [go]
 
--   repo: git://github.com/golangci/golangci-lint
-    rev: v1.24.0
-    hooks:
-      - id: golangci-lint
+    -   repo: git://github.com/pre-commit/pre-commit-hooks
+        rev: v2.5.0
+        hooks:
+        -   id: check-json
+        -   id: check-merge-conflict
+        -   id: check-yaml
+        -   id: detect-private-key
+        -   id: pretty-format-json
+            args:
+            - --autofix
+        -   id: trailing-whitespace
 
--   repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.29.0
-    hooks:
-    - id: terraform_docs
-    - id: terraform_fmt
+    -   repo: git://github.com/golangci/golangci-lint
+        rev: v1.24.0
+        hooks:
+          - id: golangci-lint
+            entry: golangci-lint run --verbose
+            verbose: true
 
--   repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
-    hooks:
-    -   id: markdownlint
+    -   repo: git://github.com/antonbabenko/pre-commit-terraform
+        rev: v1.29.0
+        hooks:
+        - id: terraform_docs
+        - id: terraform_fmt
+
+    -   repo: git://github.com/igorshubovych/markdownlint-cli
+        rev: v0.22.0
+        hooks:
+        -   id: markdownlint

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ pre_commit_tests: ensure_pre_commit ## Run pre-commit tests
 
 .PHONY: test
 test: pre_commit_tests
-	go test -count 1 -v -timeout 90m ./test/...
+	bin/make-test
 
 .PHONY: clean
 clean:
 	rm -f .*.stamp
+	rm -f bin

--- a/bin/check-go-version
+++ b/bin/check-go-version
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+set -eu -o pipefail
+
+VERSION="go1.14"
+
+GOLANG_VERSION=$(go version)
+if [[ $GOLANG_VERSION = *$VERSION* ]]; then
+  echo "Golang $GOLANG_VERSION installed"
+else
+  echo "Golang $VERSION is required to run this project! Found $GOLANG_VERSION"
+  echo "Install go with 'brew install go'"
+  echo "or if that version is ahead of ${GOLANG_VERSION} then run:"
+  echo "Run 'brew install go@1.14 && brew link --force go@1.14' to install"
+  exit 1
+fi

--- a/bin/make-test
+++ b/bin/make-test
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+go_test_output="/tmp/go-test.out"
+
+go test -short -count 1 -v -timeout 90m github.com/trussworks/terraform-aws-s3-private-bucket/test/... | tee "${go_test_output}"
+
+# Check if we are running tests inside of CircleCI by checking for a $CIRCLECI
+# environment variable. The dash after $CIRCLECI substitutes a null value if
+# CIRCLECI is unset. This prevents unbound variable errors
+if [[ -n ${CIRCLECI-} ]]; then
+    mkdir -p "${TEST_RESULTS}"/gotest
+    go-junit-report < "${go_test_output}" \
+                    > "${TEST_RESULTS}/gotest/go-test-report.xml"
+fi


### PR DESCRIPTION
# [Tracker story](https://www.pivotaltracker.com/story/show/169298624)

Just some cleanup for this repo. 😇

Changes proposed in this pull request:

-  Adds a `make-test` script which adds terratest metadata to circleci
- Adds a `check-go-version` script 
- Updates makefile, precommit, & circleci to use ^^ both scripts
- Updates circleci to run terratest job instead of validate

