### PR TITLE
remove removing the bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,3 @@ test: pre_commit_tests
 .PHONY: clean
 clean:
 	rm -f .*.stamp
-	rm -f bin


### PR DESCRIPTION
Fixes a mistake I made in a previous PR by removing the bin in the makefile. See: https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/100#discussion_r429329101