### PR TITLE
Adding variable, default values and force_destroy argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ module "aws-s3-bucket" {
 | bucket | The name of the bucket. | `string` | n/a | yes |
 | custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
 | enable\_analytics | Enables storage class analytics on the bucket. | `bool` | `true` | no |
+| enable\_bucket\_force\_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
 | inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -63,10 +63,11 @@ data "aws_iam_policy_document" "supplemental_policy" {
 }
 
 resource "aws_s3_bucket" "private_bucket" {
-  bucket = local.bucket_id
-  acl    = "private"
-  tags   = var.tags
-  policy = data.aws_iam_policy_document.supplemental_policy.json
+  bucket        = local.bucket_id
+  acl           = "private"
+  tags          = var.tags
+  policy        = data.aws_iam_policy_document.supplemental_policy.json
+  force_destroy = var.enable_bucket_force_destroy
 
   versioning {
     enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "enable_bucket_inventory" {
   description = "If set to true, Bucket Inventory will be enabled."
 }
 
+variable "enable_bucket_force_destroy" {
+  type        = bool
+  default     = false
+  description = "If set to true, Bucket will be emptied and destroyed when terraform destroy is run."
+}
+
 variable "inventory_bucket_format" {
   type        = string
   default     = "ORC"


### PR DESCRIPTION
When creating an S3 bucket through terraform, the only way to programmatically remove such bucket is by using the force_destroy argument. The argument is missing form this module, which makes using this module a bit harder when paired with your [terraform-aws-bootstrap](https://github.com/trussworks/terraform-aws-bootstrap) module.

This PR just adds the argument with a safe default of "false".