### PR TITLE
Adds bool for versioning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types: [go]
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -20,19 +20,19 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.30.0
+    rev: v1.32.2
     hooks:
       - id: golangci-lint
         entry: golangci-lint run
         verbose: true
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.44.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.24.0
     hooks:
       - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ module "aws-s3-bucket" {
 | enable\_analytics | Enables storage class analytics on the bucket. | `bool` | `true` | no |
 | enable\_bucket\_force\_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
+| enable\_versioning | Enables versioning on the bucket. | `string` | `true` | no |
 | inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
 | schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module "aws-s3-bucket" {
 | enable\_analytics | Enables storage class analytics on the bucket. | `bool` | `true` | no |
 | enable\_bucket\_force\_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
-| enable\_versioning | Enables versioning on the bucket. | `string` | `true` | no |
+| enable\_versioning | Enables versioning on the bucket. | `bool` | `true` | no |
 | inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
 | schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -10,6 +10,7 @@ module "s3_private_bucket" {
   logging_bucket           = module.s3_logs.aws_logs_bucket
   enable_analytics         = var.enable_analytics
   cors_rules               = var.cors_rules
+  enable_versioning        = var.enable_versioning
 }
 
 #

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -14,3 +14,7 @@ variable "cors_rules" {
   type    = list(any)
   default = []
 }
+
+variable "enable_versioning" {
+  type = bool
+}

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_s3_bucket" "private_bucket" {
   force_destroy = var.enable_bucket_force_destroy
 
   versioning {
-    enabled = true
+    enabled = var.enable_versioning
   }
 
   lifecycle_rule {

--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -34,10 +34,11 @@ func TestTerraformAwsS3PrivateBucket(t *testing.T) {
 
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{
-			"test_name":        testName,
-			"logging_bucket":   loggingBucket,
-			"enable_analytics": true,
-			"cors_rules":       []corsRule{rule},
+			"test_name":         testName,
+			"logging_bucket":    loggingBucket,
+			"enable_analytics":  true,
+			"cors_rules":        []corsRule{rule},
+			"enable_versioning": true,
 		},
 
 		// Environment variables to set when running Terraform

--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -79,9 +79,10 @@ func TestTerraformAwsS3PrivateBucketWithoutAnalytics(t *testing.T) {
 
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{
-			"test_name":        testName,
-			"logging_bucket":   loggingBucket,
-			"enable_analytics": false,
+			"test_name":         testName,
+			"logging_bucket":    loggingBucket,
+			"enable_analytics":  false,
+			"enable_versioning": true,
 		},
 
 		// Environment variables to set when running Terraform

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,6 @@ variable "cors_rules" {
 
 variable "enable_versioning" {
   description = "Enables versioning on the bucket."
-  type        = string
+  type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,9 @@ variable "cors_rules" {
   type        = list(any)
   default     = []
 }
+
+variable "enable_versioning" {
+  description = "Enables versioning on the bucket."
+  type        = string
+  default     = true
+}


### PR DESCRIPTION
# [No Story] - Client ticket

Adds a bool to versioning. 

On MilMove have a bucket for which we would like to remove versioning. If we can remove versioning we won't store unneeded files.  

Changes proposed in this pull request:

- Adds bool to versioning, defaulting to true so nothing breaks
- Updates terratest to reflect no breakage
- Updates precommit to appease the Terrform Docs deities

