### PR TITLE
Enable more control over current and non current object transitions and object expirations lifecycle rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ module "aws-s3-bucket" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| abort\_incomplete\_multipart\_upload\_days | Number of days until aborting incomplete multipart uploads | `number` | `14` | no |
 | bucket | The name of the bucket. | `string` | n/a | yes |
 | cors\_rules | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
 | custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
@@ -73,8 +74,11 @@ module "aws-s3-bucket" {
 | enable\_versioning | Enables versioning on the bucket. | `bool` | `true` | no |
 | inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
+| noncurrent\_version\_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
+| noncurrent\_version\_transitions | Non-current version transition blocks | `list(any)` | <pre>[<br>  {<br>    "days": 30,<br>    "storage_class": "STANDARD_IA"<br>  }<br>]</pre> | no |
 | schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
 | tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+| transitions | Current version transition blocks | `list(any)` | `[]` | no |
 | use\_account\_alias\_prefix | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |
 
 ## Outputs

--- a/examples/transitions/main.tf
+++ b/examples/transitions/main.tf
@@ -1,0 +1,39 @@
+#
+# Private Bucket with transitions
+#
+
+module "s3_private_bucket" {
+  source = "../../"
+
+  bucket                   = var.test_name
+  use_account_alias_prefix = false
+
+  abort_incomplete_multipart_upload_days = 7
+
+  transitions = [
+    {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    },
+    {
+      days          = 60
+      storage_class = "GLACIER"
+    },
+    {
+      days          = 150
+      storage_class = "DEEP_ARCHIVE"
+    }
+  ]
+
+  noncurrent_version_transitions = [
+    {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    },
+    {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+  ]
+  noncurrent_version_expiration = 90
+}

--- a/examples/transitions/variables.tf
+++ b/examples/transitions/variables.tf
@@ -1,0 +1,3 @@
+variable "test_name" {
+  type = string
+}

--- a/main.tf
+++ b/main.tf
@@ -78,19 +78,30 @@ resource "aws_s3_bucket" "private_bucket" {
   lifecycle_rule {
     enabled = true
 
-    abort_incomplete_multipart_upload_days = 14
+    abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 
     expiration {
       expired_object_delete_marker = true
     }
 
-    noncurrent_version_transition {
-      days          = 30
-      storage_class = "STANDARD_IA"
+    dynamic "transition" {
+      for_each = var.transitions
+      content {
+        days          = transition.value.days
+        storage_class = transition.value.storage_class
+      }
+    }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.noncurrent_version_transitions
+      content {
+        days          = noncurrent_version_transition.value.days
+        storage_class = noncurrent_version_transition.value.storage_class
+      }
     }
 
     noncurrent_version_expiration {
-      days = 365
+      days = var.noncurrent_version_expiration
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,3 +68,32 @@ variable "enable_versioning" {
   type        = bool
   default     = true
 }
+
+variable "abort_incomplete_multipart_upload_days" {
+  description = "Number of days until aborting incomplete multipart uploads"
+  type        = number
+  default     = 14
+}
+
+variable "transitions" {
+  description = "Current version transition blocks"
+  type        = list(any)
+  default     = []
+}
+
+variable "noncurrent_version_transitions" {
+  description = "Non-current version transition blocks"
+  type        = list(any)
+  default = [
+    {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+  ]
+}
+
+variable "noncurrent_version_expiration" {
+  description = "Number of days until non-current version of object expires"
+  type        = number
+  default     = 365
+}


### PR DESCRIPTION
This change utilizes the `dynamic` blocks in TF13 to allow setting multiple transition blocks on a resource. Here's an example of how this would look:

```hcl
module "s3_bucket" {
  source  = "trussworks/s3-private-bucket/aws"

  bucket = var.bucket_name
  tags   = var.tags

  abort_incomplete_multipart_upload_days = 7

  transitions = [
    {
      days          = 30
      storage_class = "STANDARD_IA"
    },
    {
      days          = 60
      storage_class = "GLACIER"
    },
    {
      days          = 150
      storage_class = "DEEP_ARCHIVE"
    }
  ]

  noncurrent_version_transitions = [
    {
      days          = 30
      storage_class = "STANDARD_IA"
    },
    {
      days          = 60
      storage_class = "GLACIER"
    }
  ]
  noncurrent_version_expiration = 90

  logging_bucket = module.aws_logs.aws_logs_bucket
}
```

The defaults are all set so that this change should be a no-op for folks using the defaults.