### PR TITLE
Relax version constraints for Terraform 0.14 and deprecate Terraform 0.11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         username: $DOCKER_USERNAME
       environment:
       - TEST_RESULTS: /tmp/test-results
-      image: trussworks/circleci:6986bb9022e5a83599feb66a7128a2d0fa12732a
+      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
     steps:
     - checkout
     - restore_cache:
@@ -15,19 +15,18 @@ jobs:
         - go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version"
           }}
     - run:
-        command: 'echo ''export PATH=${PATH}:~/go/bin'' >> $BASH_ENV
-
+        command: |
+          echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
           source $BASH_ENV
-
-          '
         name: Adding go binaries to $PATH
     - run: go get github.com/jstemmer/go-junit-report
     - run:
-        command: "temp_role=$(aws sts assume-role \\\n        --role-arn arn:aws:iam::313564602749:role/circleci\
-          \ \\\n        --role-session-name circleci)\nexport AWS_ACCESS_KEY_ID=$(echo\
-          \ $temp_role | jq .Credentials.AccessKeyId | xargs)\nexport AWS_SECRET_ACCESS_KEY=$(echo\
-          \ $temp_role | jq .Credentials.SecretAccessKey | xargs)\nexport AWS_SESSION_TOKEN=$(echo\
-          \ $temp_role | jq .Credentials.SessionToken | xargs)\nmake test\n"
+        command: |
+          temp_role=$(aws sts assume-role --role-arn arn:aws:iam::313564602749:role/circleci --role-session-name circleci)
+          export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+          export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+          export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+          make test
         name: Assume role and run terratest
     - save_cache:
         key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
@@ -40,8 +39,6 @@ jobs:
         - ~/go/pkg/mod
     - store_test_results:
         path: /tmp/test-results/gotest
-references:
-  circleci: trussworks/circleci:6986bb9022e5a83599feb66a7128a2d0fa12732a
 version: 2.1
 workflows:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types: [go]
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -20,19 +20,19 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.32.2
+    rev: v1.33.0
     hooks:
       - id: golangci-lint
         entry: golangci-lint run
         verbose: true
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.24.0
+    rev: v0.26.0
     hooks:
       - id: markdownlint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,35 +2,176 @@
 
 ## [Unreleased](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/HEAD)
 
-[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/2.0.8...HEAD)
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v3.2.2...HEAD)
+
+**Closed issues:**
+
+- Failed to download module with 3.2.1 [\#194](https://github.com/trussworks/terraform-aws-s3-private-bucket/issues/194)
 
 **Merged pull requests:**
 
+- Bump github.com/aws/aws-sdk-go from 1.36.2 to 1.36.7 [\#198](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/198) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/gruntwork-io/terratest from 0.30.23 to 0.31.1 [\#196](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/196) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.35.35 to 1.36.2 [\#195](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/195) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v3.2.2](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v3.2.2) (2020-12-02)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v3.2.1...v3.2.2)
+
+## [v3.2.1](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v3.2.1) (2020-12-02)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/2.2.1...v3.2.1)
+
+**Merged pull requests:**
+
+- adding simple test for new example [\#193](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/193) ([eeeady](https://github.com/eeeady))
+- Enable more control over current and non current object transitions and object expirations lifecycle rules [\#192](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/192) ([chrisgilmerproj](https://github.com/chrisgilmerproj))
+- Bump github.com/aws/aws-sdk-go from 1.35.33 to 1.35.35 [\#191](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/191) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.35.24 to 1.35.33 [\#190](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/190) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Fixing \_AWSBucketAnalytics prefix name [\#189](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/189) ([travelar](https://github.com/travelar))
+- Bump github.com/gruntwork-io/terratest from 0.30.4 to 0.30.23 [\#187](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/187) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.35.19 to 1.35.24 [\#184](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/184) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Automated CircleCI config update [\#182](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/182) ([eeeady](https://github.com/eeeady))
+
+## [2.2.1](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/2.2.1) (2020-11-23)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.2.1...2.2.1)
+
+## [v2.2.1](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.2.1) (2020-11-23)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.2.0...v2.2.1)
+
+## [v2.2.0](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.2.0) (2020-11-09)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v3.2.0...v2.2.0)
+
+## [v3.2.0](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v3.2.0) (2020-11-09)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.1.0...v3.2.0)
+
+**Merged pull requests:**
+
+- Adds bool for versioning [\#183](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/183) ([mdawn](https://github.com/mdawn))
+- Bump github.com/aws/aws-sdk-go from 1.35.14 to 1.35.19 [\#180](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/180) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.35.9 to 1.35.14 [\#178](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/178) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.35.7 to 1.35.9 [\#176](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/176) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.35.2 to 1.35.7 [\#175](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/175) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.34.32 to 1.35.2 [\#173](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/173) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.34.27 to 1.34.32 [\#172](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/172) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/gruntwork-io/terratest from 0.30.0 to 0.30.4 [\#171](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/171) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Backport CORS support to 0.12 [\#170](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/170) ([dynamike](https://github.com/dynamike))
+- add basic test [\#168](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/168) ([mdawn](https://github.com/mdawn))
+- Bump github.com/gruntwork-io/terratest from 0.28.13 to 0.28.15 [\#162](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/162) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v2.1.0](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.1.0) (2020-09-22)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v3.1.0...v2.1.0)
+
+## [v3.1.0](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v3.1.0) (2020-09-22)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v3.0.0...v3.1.0)
+
+**Merged pull requests:**
+
+- Bump github.com/aws/aws-sdk-go from 1.34.22 to 1.34.27 [\#169](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/169) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v3.0.0](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v3.0.0) (2020-09-15)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.0.11...v3.0.0)
+
+**Merged pull requests:**
+
+- Upgrade go version and terraform 13 [\#167](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/167) ([ralren](https://github.com/ralren))
+
+## [v2.0.11](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.0.11) (2020-09-14)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.0.10...v2.0.11)
+
+**Merged pull requests:**
+
+- Bump github.com/aws/aws-sdk-go from 1.34.18 to 1.34.22 [\#166](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/166) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.34.13 to 1.34.18 [\#164](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/164) ([dependabot[bot]](https://github.com/apps/dependabot))
+- upgrade circleci-docker-image to circleci [\#163](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/163) ([mdrummerboy09](https://github.com/mdrummerboy09))
+- Bump github.com/aws/aws-sdk-go from 1.34.9 to 1.34.13 [\#161](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/161) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.34.5 to 1.34.9 [\#160](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/160) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.34.0 to 1.34.5 [\#159](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/159) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/gruntwork-io/terratest from 0.28.12 to 0.28.13 [\#158](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/158) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Pin tf version to 0.12 family. Update pre-commit. [\#157](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/157) ([chrisgilmerproj](https://github.com/chrisgilmerproj))
+- Bump github.com/aws/aws-sdk-go from 1.33.17 to 1.34.0 [\#156](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/156) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Mdawn pin aws providers for terratests 174129036 [\#155](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/155) ([mdawn](https://github.com/mdawn))
+- Bump github.com/gruntwork-io/terratest from 0.28.10 to 0.28.12 [\#154](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/154) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.33.13 to 1.33.17 [\#153](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/153) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.33.11 to 1.33.13 [\#152](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/152) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Add Kodiak bot for automerging dependabot PRs [\#151](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/151) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.11 to 1.33.12 [\#149](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/149) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v2.0.10](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.0.10) (2020-07-27)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.0.9...v2.0.10)
+
+**Merged pull requests:**
+
+- Disable the data resource that retrieves the AWS account alias if not being used [\#150](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/150) ([chrisgilmerproj](https://github.com/chrisgilmerproj))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.11 [\#148](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/148) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Add forgotten comma in auto approve github action [\#147](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/147) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.11 [\#146](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/146) ([dependabot[bot]](https://github.com/apps/dependabot))
+- \(Revert aws-sdk-go again and\) have auto approve create a pr comment that auto merge will trigger on. [\#145](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/145) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.11 [\#144](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/144) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Revert aws-sdk-go and have github-actions submit an approved review [\#143](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/143) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.11 [\#142](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/142) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Change auto merge expected bot actor from dependabot to github-actions [\#141](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/141) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.11 [\#140](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/140) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Automerge if check suite is success [\#139](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/139) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.10 [\#138](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/138) ([dependabot[bot]](https://github.com/apps/dependabot))
+- experiment with github action changes [\#137](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/137) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.9 [\#135](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/135) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Copy changes from actions repo for testing [\#134](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/134) ([chrisgilmerproj](https://github.com/chrisgilmerproj))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.8 [\#133](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/133) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Fix automerge GitHub action \#2 [\#132](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/132) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.8 [\#131](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/131) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Fix automerge GitHub action [\#130](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/130) ([ralren](https://github.com/ralren))
+- Bump github.com/aws/aws-sdk-go from 1.33.7 to 1.33.8 [\#129](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/129) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/gruntwork-io/terratest from 0.27.4 to 0.28.10 [\#128](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/128) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Update Dependabot config file [\#127](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/127) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- Bump github.com/aws/aws-sdk-go from 1.33.5 to 1.33.7 [\#126](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/126) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- Bump github.com/aws/aws-sdk-go from 1.33.1 to 1.33.5 [\#124](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/124) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+
+## [v2.0.9](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.0.9) (2020-07-06)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.0.6...v2.0.9)
+
+**Merged pull requests:**
+
+- Bump github.com/aws/aws-sdk-go from 1.31.12 to 1.33.1 [\#122](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/122) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- Mdawn gussy up terratests 172808468 [\#117](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/117) ([mdawn](https://github.com/mdawn))
+
+## [v2.0.6](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.0.6) (2020-06-22)
+
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.0.8...v2.0.6)
+
+**Merged pull requests:**
+
+- Adding variable, default values and force\_destroy argument [\#118](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/118) ([Tokynet](https://github.com/Tokynet))
+- Make README pass terradocs specs [\#116](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/116) ([ralren](https://github.com/ralren))
+- GitHub changelog generator attempt [\#113](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/113) ([ralren](https://github.com/ralren))
 - Bump github.com/stretchr/testify from 1.5.1 to 1.6.1 [\#112](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/112) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
 - Bump github.com/aws/aws-sdk-go from 1.31.7 to 1.31.12 [\#111](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/111) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
 
-## [2.0.8](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/2.0.8) (2020-06-03)
+## [v2.0.8](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.0.8) (2020-06-03)
 
-[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/2.0.7...2.0.8)
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.0.7...v2.0.8)
 
 **Merged pull requests:**
 
 - Correct analytics prefix [\#109](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/109) ([ralren](https://github.com/ralren))
 
-## [2.0.7](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/2.0.7) (2020-06-03)
+## [v2.0.7](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/v2.0.7) (2020-06-03)
 
-[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/2.0.6...2.0.7)
+[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.0.5...v2.0.7)
 
 **Merged pull requests:**
 
 - Add policy so that s3 can put object in the bucket [\#108](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/108) ([ralren](https://github.com/ralren))
-
-## [2.0.6](https://github.com/trussworks/terraform-aws-s3-private-bucket/tree/2.0.6) (2020-06-01)
-
-[Full Changelog](https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/v2.0.5...2.0.6)
-
-**Merged pull requests:**
-
 - Enable storage class analytics by default [\#107](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/107) ([ralren](https://github.com/ralren))
 - Bump github.com/aws/aws-sdk-go from 1.31.4 to 1.31.7 [\#106](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/106) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
 - Bump github.com/aws/aws-sdk-go from 1.30.29 to 1.31.4 [\#103](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/103) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ Terraform 0.13. Pin module version to ~> 3.X. Submit pull-requests to master bra
 
 Terraform 0.12. Pin module version to ~> 2.X.  Submit pull-requests to terraform012 branch.
 
-Terraform 0.11. Pin module version to ~> 1.7.3. Submit pull-requests to terraform011 branch.
-
 ## Usage
 
 ```hcl
@@ -51,14 +49,14 @@ module "aws-s3-bucket" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
-| aws | ~> 3.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following lifecycle rules are set:
 
 ## Terraform Versions
 
-Terraform 0.13. Pin module version to ~> 3.X. Submit pull-requests to master branch.
+Terraform 0.13 and newer. Pin module version to ~> 3.X. Submit pull-requests to master branch.
 
 Terraform 0.12. Pin module version to ~> 2.X.  Submit pull-requests to terraform012 branch.
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
This will allow folks on Terraform 0.14 to use this module by setting the minimal supported Terraform version. This is aligned with [Terraforms best practices around versioning](https://www.terraform.io/docs/configuration/version-constraints.html#terraform-core-and-provider-versions). CI tests will also will be using the same version. Lastly, this PR cleans up the CircleCI config and updates pre-commit hooks.  

Once merged, I will remove the `terraform011` branch.

Resolves https://github.com/trussworks/terraform-aws-s3-private-bucket/issues/197