### PR TITLE
Relax provider version for 0.12 branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types: [go]
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -20,19 +20,19 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.30.0
+    rev: v1.33.0
     hooks:
       - id: golangci-lint
         entry: golangci-lint run
         verbose: true
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.26.0
     hooks:
       - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ The following lifecycle rules are set:
 
 ## Terraform Versions
 
-Terraform 0.12. Pin module version to ~> 2.0.0. Submit pull-requests to master branch.
+Terraform 0.13 and newer. Pin module version to ~> 3.X. Submit pull-requests to master branch.
 
-Terraform 0.11. Pin module version to ~> 1.7.3. Submit pull-requests to terraform011 branch.
+Terraform 0.12. Pin module version to ~> 2.0.0. Submit pull-requests to terraform012 branch.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ module "aws-s3-bucket" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| aws | >= 2.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | >= 2.70 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = ">= 2.70"
   }
 }


### PR DESCRIPTION
Another quick PR relaxing the AWS provider constraint so that this module can be used in projects using the 3.x AWS provider and Terraform 0.12.
