### PR TITLE
Allow users to supply customer managed KMS keys for encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ module "aws-s3-bucket" {
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
 | enable\_versioning | Enables versioning on the bucket. | `bool` | `true` | no |
 | inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
+| kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `""` | no |
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
 | noncurrent\_version\_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
 | noncurrent\_version\_transitions | Non-current version transition blocks | `list(any)` | <pre>[<br>  {<br>    "days": 30,<br>    "storage_class": "STANDARD_IA"<br>  }<br>]</pre> | no |
 | schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
+| sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
 | tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | transitions | Current version transition blocks | `list(any)` | `[]` | no |
 | use\_account\_alias\_prefix | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -136,7 +136,8 @@ resource "aws_s3_bucket" "private_bucket" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
+        sse_algorithm     = var.sse_algorithm
+        kms_master_key_id = length(var.kms_master_key_id) > 0 ? var.kms_master_key_id : null
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -97,3 +97,15 @@ variable "noncurrent_version_expiration" {
   type        = number
   default     = 365
 }
+
+variable "sse_algorithm" {
+  description = "The server-side encryption algorithm to use. Valid values are AES256 and aws:kms"
+  type        = string
+  default     = "AES256"
+}
+
+variable "kms_master_key_id" {
+  description = "The AWS KMS master key ID used for the SSE-KMS encryption."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
I would like to supply a customer managed key to this module but it required a change. This should be a no-op for existing users. Folks that wish to update their key can choose to do so. I've tested both configurations of this module.