### PR TITLE
Add expiration variables to control expiration lifecycle policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ module "aws-s3-bucket" {
 | enable\_bucket\_force\_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
 | enable\_versioning | Enables versioning on the bucket. | `bool` | `true` | no |
+| expiration\_date | Specifies the date after which you want the corresponding action to take effect. | `string` | `""` | no |
+| expiration\_days | Specifies the number of days after object creation when the specific rule action takes effect. | `number` | `0` | no |
 | inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
 | kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `""` | no |
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,9 @@ resource "aws_s3_bucket" "private_bucket" {
     abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 
     expiration {
+      date = length(var.expiration_date) > 0 ? var.expiration_date : null
+      days = var.expiration_days > 0 ? var.expiration_days : 0
+
       expired_object_delete_marker = true
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,15 @@ variable "kms_master_key_id" {
   type        = string
   default     = ""
 }
+
+variable "expiration_date" {
+  type        = string
+  default     = ""
+  description = "Specifies the date after which you want the corresponding action to take effect."
+}
+
+variable "expiration_days" {
+  type        = number
+  default     = 0
+  description = "Specifies the number of days after object creation when the specific rule action takes effect."
+}


### PR DESCRIPTION
I'd like to be able to set the expiration values on the expiration lifecycle policy as mentioned here:

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#expiration

I modified the policy to be a no-op for current users of the module and tested it on a local system.

Another way to handle the lifecycle `expiration` policy might be to use dynamic blocks for this to give users more control, but then its possible they might try to use the module without the expiration block. Let me know what you want to do on that and I can update the PR if needed.