### PR TITLE
Use a variable to define expiration blocks similar to transition and noncurrent_version_transition is done.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,65 +49,65 @@ module "aws-s3-bucket" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_iam_account_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) |
-| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
-| [aws_s3_bucket_analytics_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) |
-| [aws_s3_bucket_inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) |
-| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) |
+| Name | Type |
+|------|------|
+| [aws_s3_bucket.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_analytics_configuration.private_analytics_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) | resource |
+| [aws_s3_bucket_inventory.inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) | resource |
+| [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_account_alias.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias) | data source |
+| [aws_iam_policy_document.supplemental_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| abort\_incomplete\_multipart\_upload\_days | Number of days until aborting incomplete multipart uploads | `number` | `14` | no |
-| bucket | The name of the bucket. | `string` | n/a | yes |
-| cors\_rules | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
-| custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
-| enable\_analytics | Enables storage class analytics on the bucket. | `bool` | `true` | no |
-| enable\_bucket\_force\_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
-| enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
-| enable\_versioning | Enables versioning on the bucket. | `bool` | `true` | no |
-| expiration | expiration blocks | `list(any)` | <pre>[<br>  {<br>    "expired_object_delete_marker": true<br>  }<br>]</pre> | no |
-| inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
-| kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `""` | no |
-| logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
-| noncurrent\_version\_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
-| noncurrent\_version\_transitions | Non-current version transition blocks | `list(any)` | <pre>[<br>  {<br>    "days": 30,<br>    "storage_class": "STANDARD_IA"<br>  }<br>]</pre> | no |
-| schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
-| sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
-| tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
-| transitions | Current version transition blocks | `list(any)` | `[]` | no |
-| use\_account\_alias\_prefix | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |
+| <a name="input_abort_incomplete_multipart_upload_days"></a> [abort\_incomplete\_multipart\_upload\_days](#input\_abort\_incomplete\_multipart\_upload\_days) | Number of days until aborting incomplete multipart uploads | `number` | `14` | no |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | The name of the bucket. | `string` | n/a | yes |
+| <a name="input_cors_rules"></a> [cors\_rules](#input\_cors\_rules) | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
+| <a name="input_custom_bucket_policy"></a> [custom\_bucket\_policy](#input\_custom\_bucket\_policy) | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
+| <a name="input_enable_analytics"></a> [enable\_analytics](#input\_enable\_analytics) | Enables storage class analytics on the bucket. | `bool` | `true` | no |
+| <a name="input_enable_bucket_force_destroy"></a> [enable\_bucket\_force\_destroy](#input\_enable\_bucket\_force\_destroy) | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
+| <a name="input_enable_bucket_inventory"></a> [enable\_bucket\_inventory](#input\_enable\_bucket\_inventory) | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
+| <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Enables versioning on the bucket. | `bool` | `true` | no |
+| <a name="input_expiration"></a> [expiration](#input\_expiration) | expiration blocks | `list(any)` | <pre>[<br>  {<br>    "expired_object_delete_marker": true<br>  }<br>]</pre> | no |
+| <a name="input_inventory_bucket_format"></a> [inventory\_bucket\_format](#input\_inventory\_bucket\_format) | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
+| <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `""` | no |
+| <a name="input_logging_bucket"></a> [logging\_bucket](#input\_logging\_bucket) | The S3 bucket to send S3 access logs. | `string` | `""` | no |
+| <a name="input_noncurrent_version_expiration"></a> [noncurrent\_version\_expiration](#input\_noncurrent\_version\_expiration) | Number of days until non-current version of object expires | `number` | `365` | no |
+| <a name="input_noncurrent_version_transitions"></a> [noncurrent\_version\_transitions](#input\_noncurrent\_version\_transitions) | Non-current version transition blocks | `list(any)` | <pre>[<br>  {<br>    "days": 30,<br>    "storage_class": "STANDARD_IA"<br>  }<br>]</pre> | no |
+| <a name="input_schedule_frequency"></a> [schedule\_frequency](#input\_schedule\_frequency) | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
+| <a name="input_sse_algorithm"></a> [sse\_algorithm](#input\_sse\_algorithm) | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+| <a name="input_transitions"></a> [transitions](#input\_transitions) | Current version transition blocks | `list(any)` | `[]` | no |
+| <a name="input_use_account_alias_prefix"></a> [use\_account\_alias\_prefix](#input\_use\_account\_alias\_prefix) | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| arn | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
-| bucket\_domain\_name | The bucket domain name. |
-| bucket\_regional\_domain\_name | The bucket region-specific domain name. |
-| id | The name of the bucket. |
-| name | The Name of the bucket. Will be of format bucketprefix-bucketname. |
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
+| <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | The bucket domain name. |
+| <a name="output_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#output\_bucket\_regional\_domain\_name) | The bucket region-specific domain name. |
+| <a name="output_id"></a> [id](#output\_id) | The name of the bucket. |
+| <a name="output_name"></a> [name](#output\_name) | The Name of the bucket. Will be of format bucketprefix-bucketname. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Developer Setup

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ module "aws-s3-bucket" {
 |------|---------|
 | aws | >= 3.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_iam_account_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
+| [aws_s3_bucket_analytics_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) |
+| [aws_s3_bucket_inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -70,8 +87,7 @@ module "aws-s3-bucket" {
 | enable\_bucket\_force\_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
 | enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
 | enable\_versioning | Enables versioning on the bucket. | `bool` | `true` | no |
-| expiration\_date | Specifies the date after which you want the corresponding action to take effect. | `string` | `""` | no |
-| expiration\_days | Specifies the number of days after object creation when the specific rule action takes effect. | `number` | `0` | no |
+| expiration | expiration blocks | `list(any)` | <pre>[<br>  {<br>    "expired_object_delete_marker": true<br>  }<br>]</pre> | no |
 | inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
 | kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `""` | no |
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
@@ -92,7 +108,6 @@ module "aws-s3-bucket" {
 | bucket\_regional\_domain\_name | The bucket region-specific domain name. |
 | id | The name of the bucket. |
 | name | The Name of the bucket. Will be of format bucketprefix-bucketname. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Developer Setup

--- a/examples/object-expiration/main.tf
+++ b/examples/object-expiration/main.tf
@@ -1,0 +1,21 @@
+#
+# Private Bucket with object expiration
+#
+
+module "s3_private_bucket" {
+  source = "../../"
+
+  bucket                   = var.test_name
+  use_account_alias_prefix = false
+
+  abort_incomplete_multipart_upload_days = 7
+
+  expiration = [
+    {
+      days = 7
+      # when days pr date is set the expiration object delete marker cannot be set to true
+      # if it is set to true then terraform plans will continue to attempt to set it each time a plan is applied
+      expiration_object_delete_marker = false
+    }
+  ]
+}

--- a/examples/object-expiration/variables.tf
+++ b/examples/object-expiration/variables.tf
@@ -1,0 +1,3 @@
+variable "test_name" {
+  type = string
+}

--- a/main.tf
+++ b/main.tf
@@ -80,11 +80,14 @@ resource "aws_s3_bucket" "private_bucket" {
 
     abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 
-    expiration {
-      date = length(var.expiration_date) > 0 ? var.expiration_date : null
-      days = var.expiration_days > 0 ? var.expiration_days : 0
+    dynamic "expiration" {
+      for_each = var.expiration
+      content {
+        date = lookup(expiration.value, "date", null)
+        days = lookup(expiration.value, "days", 0)
 
-      expired_object_delete_marker = true
+        expired_object_delete_marker = lookup(expiration.value, "expired_object_delete_marker", false)
+      }
     }
 
     dynamic "transition" {

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,16 @@ variable "abort_incomplete_multipart_upload_days" {
   default     = 14
 }
 
+variable "expiration" {
+  description = "expiration blocks"
+  type        = list(any)
+  default = [
+    {
+      expired_object_delete_marker = true
+    }
+  ]
+}
+
 variable "transitions" {
   description = "Current version transition blocks"
   type        = list(any)
@@ -108,16 +118,4 @@ variable "kms_master_key_id" {
   description = "The AWS KMS master key ID used for the SSE-KMS encryption."
   type        = string
   default     = ""
-}
-
-variable "expiration_date" {
-  type        = string
-  default     = ""
-  description = "Specifies the date after which you want the corresponding action to take effect."
-}
-
-variable "expiration_days" {
-  type        = number
-  default     = 0
-  description = "Specifies the number of days after object creation when the specific rule action takes effect."
 }


### PR DESCRIPTION
In #220 I didn't realize you couldn't set `date` or `days` and also set `expired_object_delete_marker`. I could change the code to do something fancy with `expiration_days` variable I introduced or I could simplify the logic to work like the other lifecycle policy blocks. I've chosen the latter and set the default to be what it always was, meaning a no-op for users.

From the [TF Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#expired_object_delete_marker):

> expired_object_delete_marker (Optional) On a versioned bucket (versioning-enabled or versioning-suspended bucket), you can add this element in the lifecycle configuration to direct Amazon S3 to delete expired object delete markers. This cannot be specified with Days or Date in a Lifecycle Expiration Policy.