### PR TITLE
Provide an upgrade path to AWS provider 4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         username: $DOCKER_USERNAME
       environment:
       - TEST_RESULTS: /tmp/test-results
-      image: trussworks/circleci:03d0d0dcd05dad6cc03b570e5128c735ea90c80f
+      image: trussworks/circleci:2218890b0ada8cec21782f9799329c4422fa362b
     steps:
     - checkout
     - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,7 @@ jobs:
     - restore_cache:
         keys:
         - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-        - go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version"
-          }}
+        - go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version" }}
     - run:
         command: |
           echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
@@ -33,8 +32,7 @@ jobs:
         paths:
         - ~/.cache
     - save_cache:
-        key: go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version"
-          }}
+        key: go-mod-sources-v1-{{ checksum "go.sum" }}-{{ checksum "bin/check-go-version" }}
         paths:
         - ~/go/pkg/mod
     - store_test_results:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,8 @@
 linters:
   enable:
      - gosec
-     - golint
      - gofmt
      - goimports
+     - revive
   disable:
     - typecheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
     hooks:
       - id: golangci-lint
         args: [--timeout=3m]
-        verbose: true
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.69.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
         language: script
         types: [go]
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -19,20 +19,20 @@ repos:
           - --autofix
       - id: trailing-whitespace
 
-  - repo: git://github.com/golangci/golangci-lint
-    rev: v1.41.1
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.45.2
     hooks:
       - id: golangci-lint
         args: [--timeout=3m]
         verbose: true
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.50.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.69.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.28.1
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.31.1
     hooks:
       - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ No modules.
 | [aws_s3_bucket.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_analytics_configuration.private_analytics_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) | resource |
 | [aws_s3_bucket_inventory.inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) | resource |
+| [aws_s3_bucket_lifecycle_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_versioning.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ No modules.
 | [aws_s3_bucket_analytics_configuration.private_analytics_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) | resource |
 | [aws_s3_bucket_inventory.inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) | resource |
 | [aws_s3_bucket_lifecycle_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_logging.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_versioning.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ No modules.
 |------|------|
 | [aws_s3_bucket.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_analytics_configuration.private_analytics_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) | resource |
+| [aws_s3_bucket_cors_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
 | [aws_s3_bucket_inventory.inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) | resource |
 | [aws_s3_bucket_lifecycle_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ module "aws-s3-bucket" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0, < 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0, < 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ No modules.
 | [aws_s3_bucket_analytics_configuration.private_analytics_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) | resource |
 | [aws_s3_bucket_inventory.inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_versioning.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_account_alias.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias) | data source |
 | [aws_iam_policy_document.supplemental_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -88,7 +89,6 @@ No modules.
 | <a name="input_enable_bucket_force_destroy"></a> [enable\_bucket\_force\_destroy](#input\_enable\_bucket\_force\_destroy) | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
 | <a name="input_enable_bucket_inventory"></a> [enable\_bucket\_inventory](#input\_enable\_bucket\_inventory) | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
 | <a name="input_enable_s3_public_access_block"></a> [enable\_s3\_public\_access\_block](#input\_enable\_s3\_public\_access\_block) | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
-| <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Enables versioning on the bucket. | `bool` | `true` | no |
 | <a name="input_expiration"></a> [expiration](#input\_expiration) | expiration blocks | `list(any)` | <pre>[<br>  {<br>    "expired_object_delete_marker": true<br>  }<br>]</pre> | no |
 | <a name="input_inventory_bucket_format"></a> [inventory\_bucket\_format](#input\_inventory\_bucket\_format) | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
 | <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `""` | no |
@@ -100,6 +100,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | <a name="input_transitions"></a> [transitions](#input\_transitions) | Current version transition blocks | `list(any)` | `[]` | no |
 | <a name="input_use_account_alias_prefix"></a> [use\_account\_alias\_prefix](#input\_use\_account\_alias\_prefix) | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |
+| <a name="input_versioning_status"></a> [versioning\_status](#input\_versioning\_status) | A string that indicates the versioning status for the log bucket. | `string` | `"Enabled"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ No modules.
 | [aws_s3_bucket_inventory.inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) | resource |
 | [aws_s3_bucket_lifecycle_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_policy.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ No modules.
 | [aws_s3_bucket_lifecycle_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_account_alias.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias) | data source |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_analytics_configuration.private_analytics_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) | resource |
 | [aws_s3_bucket_cors_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
 | [aws_s3_bucket_inventory.inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) | resource |

--- a/bin/check-go-version
+++ b/bin/check-go-version
@@ -1,8 +1,8 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 
-VERSION="go1.17 linux/amd64"
+VERSION="go1.17"
 
 GOLANG_VERSION=$(go version)
 if [[ $GOLANG_VERSION = *$VERSION* ]]; then
@@ -11,6 +11,6 @@ else
   echo "Golang $VERSION is required to run this project! Found $GOLANG_VERSION"
   echo "Install go with 'brew install go'"
   echo "or if that version is ahead of ${GOLANG_VERSION} then run:"
-  echo "Run 'brew install go@1.15 && brew link --force go@1.15' to install"
+  echo "Run 'brew install go@1.17 && brew link --force go@1.17' to install"
   exit 1
 fi

--- a/examples/bucket-inventory/main.tf
+++ b/examples/bucket-inventory/main.tf
@@ -8,8 +8,12 @@ module "s3_private_bucket" {
 
   bucket                   = var.test_name
   use_account_alias_prefix = false
-  logging_bucket           = module.s3_logs.aws_logs_bucket
+  logging_bucket           = var.logging_bucket
   enable_bucket_inventory  = true
+
+  depends_on = [
+    module.s3_logs
+  ]
 }
 
 #

--- a/examples/custom-bucket-policy/main.tf
+++ b/examples/custom-bucket-policy/main.tf
@@ -39,7 +39,11 @@ module "s3_private_bucket" {
   bucket                   = var.test_name
   custom_bucket_policy     = data.aws_iam_policy_document.custom_bucket_policy.json
   use_account_alias_prefix = false
-  logging_bucket           = module.s3_logs.aws_logs_bucket
+  logging_bucket           = var.logging_bucket
+
+  depends_on = [
+    module.s3_logs
+  ]
 }
 
 #

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -10,7 +10,7 @@ module "s3_private_bucket" {
   logging_bucket           = module.s3_logs.aws_logs_bucket
   enable_analytics         = var.enable_analytics
   cors_rules               = var.cors_rules
-  enable_versioning        = var.enable_versioning
+  versioning_status        = var.versioning_status
 }
 
 #

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -7,10 +7,14 @@ module "s3_private_bucket" {
 
   bucket                   = var.test_name
   use_account_alias_prefix = false
-  logging_bucket           = module.s3_logs.aws_logs_bucket
+  logging_bucket           = var.logging_bucket
   enable_analytics         = var.enable_analytics
   cors_rules               = var.cors_rules
   versioning_status        = var.versioning_status
+
+  depends_on = [
+    module.s3_logs
+  ]
 }
 
 #

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -15,6 +15,6 @@ variable "cors_rules" {
   default = []
 }
 
-variable "enable_versioning" {
-  type = bool
+variable "versioning_status" {
+  type = string
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,90 @@
 module github.com/trussworks/terraform-aws-s3-private-bucket
 
-go 1.15
+go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.44.4
 	github.com/gruntwork-io/terratest v0.40.7
 	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	cloud.google.com/go v0.83.0 // indirect
+	cloud.google.com/go/storage v1.10.0 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
+	github.com/go-errors/errors v1.0.2-0.20180813162953-d98b870cc4e0 // indirect
+	github.com/go-logr/logr v0.2.0 // indirect
+	github.com/go-sql-driver/mysql v1.4.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/gruntwork-io/go-commons v0.8.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-getter v1.5.9 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-safetemp v1.0.0 // indirect
+	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.9.1 // indirect
+	github.com/hashicorp/terraform-json v0.13.0 // indirect
+	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/klauspost/compress v1.13.0 // indirect
+	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pquerna/otp v1.2.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tmccombs/hcl2json v0.3.3 // indirect
+	github.com/ulikunitz/xz v0.5.8 // indirect
+	github.com/urfave/cli v1.22.2 // indirect
+	github.com/zclconf/go-cty v1.9.1 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/tools v0.1.2 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/api v0.47.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/api v0.20.6 // indirect
+	k8s.io/apimachinery v0.20.6 // indirect
+	k8s.io/client-go v0.20.6 // indirect
+	k8s.io/klog/v2 v2.4.0 // indirect
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.3 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -288,7 +288,6 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 h1:yY9rWGoXv1U5pl4gxqlULARMQD7x0QG85lqEXTWysik=
 github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
-github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,6 @@ data "aws_iam_policy_document" "supplemental_policy" {
 
 resource "aws_s3_bucket" "private_bucket" {
   bucket        = local.bucket_id
-  acl           = "private"
   tags          = var.tags
   force_destroy = var.enable_bucket_force_destroy
 
@@ -107,6 +106,11 @@ resource "aws_s3_bucket" "private_bucket" {
 resource "aws_s3_bucket_policy" "private_bucket" {
   bucket = aws_s3_bucket.private_bucket.id
   policy = data.aws_iam_policy_document.supplemental_policy.json
+}
+
+resource "aws_s3_bucket_acl" "private_bucket" {
+  bucket = aws_s3_bucket.private_bucket.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "private_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,16 @@ locals {
 
 data "aws_iam_policy_document" "supplemental_policy" {
 
-  source_json = var.custom_bucket_policy
+  # This should be a single line:
+  # source_policy_documents = [var.custom_bucket_policy]
+  #
+  # However, there appears to be a bug that occurs when source_policy_documents is an empty string:
+  # - https://github.com/hashicorp/terraform-provider-aws/issues/22959
+  # - https://github.com/hashicorp/terraform-provider-aws/issues/24366
+  #
+  # To work around this, we're using this workaround. It should be replaced
+  # once the underlying issue is addressed.
+  source_policy_documents = length(var.custom_bucket_policy) > 0 ? [var.custom_bucket_policy] : null
 
   #
   # Enforce SSL/TLS on all transmitted objects

--- a/main.tf
+++ b/main.tf
@@ -71,10 +71,6 @@ resource "aws_s3_bucket" "private_bucket" {
   policy        = data.aws_iam_policy_document.supplemental_policy.json
   force_destroy = var.enable_bucket_force_destroy
 
-  versioning {
-    enabled = var.enable_versioning
-  }
-
   lifecycle_rule {
     enabled = true
 
@@ -159,6 +155,14 @@ resource "aws_s3_bucket" "private_bucket" {
       expose_headers  = lookup(cors_rule.value, "expose_headers", null)
       max_age_seconds = lookup(cors_rule.value, "max_age_seconds", null)
     }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "private_bucket" {
+  bucket = aws_s3_bucket.private_bucket.id
+
+  versioning_configuration {
+    status = var.versioning_status
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,6 @@ resource "aws_s3_bucket" "private_bucket" {
   bucket        = local.bucket_id
   acl           = "private"
   tags          = var.tags
-  policy        = data.aws_iam_policy_document.supplemental_policy.json
   force_destroy = var.enable_bucket_force_destroy
 
   lifecycle {
@@ -103,6 +102,11 @@ resource "aws_s3_bucket" "private_bucket" {
       server_side_encryption_configuration,
     ]
   }
+}
+
+resource "aws_s3_bucket_policy" "private_bucket" {
+  bucket = aws_s3_bucket.private_bucket.id
+  policy = data.aws_iam_policy_document.supplemental_policy.json
 }
 
 resource "aws_s3_bucket_versioning" "private_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -156,6 +156,36 @@ resource "aws_s3_bucket" "private_bucket" {
       max_age_seconds = lookup(cors_rule.value, "max_age_seconds", null)
     }
   }
+
+  lifecycle {
+    # These lifecycle ignore_changes rules exist to permit a smooth upgrade
+    # path from version 3.x of the AWS provider to version 4.x
+    ignore_changes = [
+      # While no special usage instructions are documented for needing this
+      # ignore_changes rule, changes are still detected during the upgrade
+      # process, so this serves to avoid drift detection since the
+      # aws_s3_bucket_policy will be used instead.
+      policy,
+
+      # While no special usage instructions are documented for needing this
+      # ignore_changes rule, this should avoid drift detection if conflicts
+      # with the aws_s3_bucket_versioning exist.
+      versioning,
+
+      # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.1/docs/resources/s3_bucket_acl#usage-notes
+      acl,
+      grant,
+
+      # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.1/docs/resources/s3_bucket_lifecycle_configuration#usage-notes
+      lifecycle_rule,
+
+      # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.1/docs/resources/s3_bucket_logging#usage-notes
+      logging,
+
+      # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.1/docs/resources/s3_bucket_server_side_encryption_configuration#usage-notes
+      server_side_encryption_configuration,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_versioning" "private_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -71,14 +71,6 @@ resource "aws_s3_bucket" "private_bucket" {
   policy        = data.aws_iam_policy_document.supplemental_policy.json
   force_destroy = var.enable_bucket_force_destroy
 
-  dynamic "logging" {
-    for_each = local.enable_bucket_logging ? [1] : []
-    content {
-      target_bucket = var.logging_bucket
-      target_prefix = "s3/${local.bucket_id}/"
-    }
-  }
-
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -210,6 +202,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
       days = 30
     }
   }
+}
+
+resource "aws_s3_bucket_logging" "private_bucket" {
+  count = local.enable_bucket_logging ? 1 : 0
+
+  bucket = aws_s3_bucket.private_bucket.id
+
+  target_bucket = var.logging_bucket
+  target_prefix = "s3/${local.bucket_id}/"
 }
 
 resource "aws_s3_bucket_analytics_configuration" "private_analytics_config" {

--- a/main.tf
+++ b/main.tf
@@ -71,16 +71,6 @@ resource "aws_s3_bucket" "private_bucket" {
   policy        = data.aws_iam_policy_document.supplemental_policy.json
   force_destroy = var.enable_bucket_force_destroy
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm     = var.sse_algorithm
-        kms_master_key_id = length(var.kms_master_key_id) > 0 ? var.kms_master_key_id : null
-      }
-      bucket_key_enabled = var.bucket_key_enabled
-    }
-  }
-
   dynamic "cors_rule" {
     for_each = var.cors_rules
 
@@ -211,6 +201,18 @@ resource "aws_s3_bucket_logging" "private_bucket" {
 
   target_bucket = var.logging_bucket
   target_prefix = "s3/${local.bucket_id}/"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "private_bucket" {
+  bucket = aws_s3_bucket.private_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = var.sse_algorithm
+      kms_master_key_id = length(var.kms_master_key_id) > 0 ? var.kms_master_key_id : null
+    }
+    bucket_key_enabled = var.bucket_key_enabled
+  }
 }
 
 resource "aws_s3_bucket_analytics_configuration" "private_analytics_config" {

--- a/test/terraform_aws_s3_private_bucket_test.go
+++ b/test/terraform_aws_s3_private_bucket_test.go
@@ -38,7 +38,7 @@ func TestTerraformAwsS3PrivateBucket(t *testing.T) {
 			"logging_bucket":    loggingBucket,
 			"enable_analytics":  true,
 			"cors_rules":        []corsRule{rule},
-			"enable_versioning": true,
+			"versioning_status": "Enabled",
 		},
 
 		// Environment variables to set when running Terraform
@@ -82,7 +82,7 @@ func TestTerraformAwsS3PrivateBucketWithoutAnalytics(t *testing.T) {
 			"test_name":         testName,
 			"logging_bucket":    loggingBucket,
 			"enable_analytics":  false,
-			"enable_versioning": true,
+			"versioning_status": "Enabled",
 		},
 
 		// Environment variables to set when running Terraform

--- a/variables.tf
+++ b/variables.tf
@@ -63,10 +63,14 @@ variable "cors_rules" {
   default     = []
 }
 
-variable "enable_versioning" {
-  description = "Enables versioning on the bucket."
-  type        = bool
-  default     = true
+variable "versioning_status" {
+  description = "A string that indicates the versioning status for the log bucket."
+  default     = "Enabled"
+  type        = string
+  validation {
+    condition     = contains(["Enabled", "Disabled", "Suspended"], var.versioning_status)
+    error_message = "Valid values for versioning_status are Enabled, Disabled, or Suspended."
+  }
 }
 
 variable "abort_incomplete_multipart_upload_days" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.0, < 4.0"
+    aws = ">= 3.75.0"
   }
 }


### PR DESCRIPTION
- BREAKING CHANGE: Replaced `enable_versioning` variable (bool) with `versioning_status` (string).
- Migrated all the relevant S3 bucket resources out of `aws_s3_bucket` and into their new respective resources as described in https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade
- Set the minimum AWS provider version to 3.75.0, which is the version that contains backported AWS S3 resource functionality that was added in 4.0.
- Updated examples and tests so they reflect the new changes.
- Updated pre-commit hooks, CircleCI image version, Go version, and switched from golint to revive for golanglint-ci.
- Added instructions for how to upgrade once the breaking change is released along with the module version bump.
- Fixed some issues with CI that were causing flakey tests due to interdependent resources.