### PR TITLE
Remove unintentional acl argument to avoid 4.0 deprecation warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,6 @@ data "aws_iam_policy_document" "supplemental_policy" {
 resource "aws_s3_bucket" "private_bucket" {
   bucket        = var.use_random_suffix ? null : local.bucket_id
   bucket_prefix = var.use_random_suffix ? local.bucket_id : null
-  acl           = "private"
   tags          = var.tags
   force_destroy = var.enable_bucket_force_destroy
 


### PR DESCRIPTION
Looks like recent PR #378 unintentionally also added back the "acl" argument which was ported out from 3.xx to 4.xx upgradation PR (#368) to resource "aws_s3_bucket_acl" . This is giving a warning.

```
│ Warning: Argument is deprecated
│ 
│   with module.terraform_state_bucket.aws_s3_bucket.private_bucket,
│   on .terraform/modules/terraform_state_bucket/main.tf line 79, in resource "aws_s3_bucket" "private_bucket":
│   79:   acl           = "private"
│ 
│ Use the aws_s3_bucket_acl resource instead
│ 
```