### PR TITLE
[MB-14792] Adds the ability to dynamically create lifecycle rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | abort\_incomplete\_multipart\_upload\_days | Number of days until aborting incomplete multipart uploads | `number` | `14` | no |
+| additional\_lifecycle\_rules | List of additional lifecycle rules to specify | `list(any)` | `[]` | no |
 | bucket | The name of the bucket. | `string` | n/a | yes |
 | bucket\_key\_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
 | cors\_rules | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -220,6 +220,21 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
       days = 30
     }
   }
+
+  dynamic "rule" {
+    for_each = var.additional_lifecycle_rules
+    content {
+      id     = rule.value["id"]
+      status = rule.value["status"]
+      filter {
+        prefix = rule.value["prefix"]
+      }
+
+      expiration {
+        days = rule.value["days"]
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_logging" "private_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -226,12 +226,17 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
     content {
       id     = rule.value["id"]
       status = rule.value["status"]
-      filter {
-        prefix = rule.value["prefix"]
+      dynamic "filter" {
+        for_each = rule.value.filter
+        content {
+          prefix = filter.value["prefix"]
+        }
       }
-
-      expiration {
-        days = rule.value["days"]
+      dynamic "expiration" {
+        for_each = rule.value.expiration
+        content {
+          days = expiration.value["days"]
+        }
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -147,3 +147,9 @@ variable "transfer_acceleration" {
   type        = bool
   default     = null
 }
+
+variable "additional_lifecycle_rules" {
+  description = "List of additional lifecycle rules to specify"
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
- Adds the variable `additional_lifecycle_rules` which allows a user to specify new rules dynamically
- variable defaults to empty list, so non-breaking change