### PR TITLE
Add null validation on aws_s3_bucket_server_side_encryption_configura…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -252,6 +252,8 @@ resource "aws_s3_bucket_logging" "private_bucket" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "private_bucket" {
+  count = var.kms_master_key_id != null ? 1 : 0
+
   bucket = aws_s3_bucket.private_bucket.id
 
   rule {


### PR DESCRIPTION
Hi 

Adding a null validation for `kms_master_key_id` on `aws_s3_bucket_server_side_encryption_configuration` resource

Related to #399 issue