### PR TITLE
Update the module based on AWS changes to S3 bucket default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ Steps for updating existing buckets managed by this module:
   input variables. Using those settings will disable S3 access control lists for
   the bucket and set object ownership to `BucketOwnerEnforced`.
 
-- **Option 2: Continue using ACLs.** To continue using ACLs, set
-  `object_ownership` to `ObjectWriter` or `BucketOwnerPreferred`.
+- **Option 2: Continue using ACLs.** To continue using ACLs, set `s3_bucket_acl`
+  to `"private"` and `object_ownership` to `"ObjectWriter"` or
+  `"BucketOwnerPreferred"`.
 
 See [Controlling ownership of objects and disabling ACLs for your
 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)

--- a/README.md
+++ b/README.md
@@ -149,12 +149,7 @@ New variables:
 - `object_ownership`
 - `s3_bucket_acl`
 
-Using the module's default values will not create the
-`aws_s3_bucket_ownership_controls.private_bucket` or
-`aws_s3_bucket_acl.private_bucket` resources and will instead use the AWS
-defaults for the configurations managed by those resources.
-
-Steps for updating existing buckets managed by this module:
+Steps for updating **existing buckets** managed by this module:
 
 - Option 1: Use new AWS recommended defaults.
 
@@ -165,7 +160,7 @@ set the following input variable value:
 control_object_ownership = true
 ```
 
-This will disable S3 access control lists for the bucket and set object
+The above will disable S3 access control lists for the bucket and set object
 ownership to `BucketOwnerEnforced`.
 
 - Option 2: Preserve existing bucket configuration as-is.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ No modules.
 
 ## Upgrade Paths
 
-### Upgrading from 4.x.x to 5.x.x
+### Upgrading from 5.x.x to 6.x.x
 
 Version 5.x.x updates the module to account for changes made by AWS in April
 2023 to the default security settings of new S3 buckets.
@@ -159,6 +159,13 @@ Steps for updating existing buckets managed by this module:
 See [Controlling ownership of objects and disabling ACLs for your
 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)
 for further details and migration considerations.
+
+### Upgrading from 4.x.x to 5.x.x
+
+Removed variables:
+
+- `sse_algorithm`. If `kms_master_key_id` is not passed, the module will fall
+  back to AES256 for the bucket encryption configuration.
 
 ### Upgrading from 3.x.x to 4.x.x
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ No modules.
 | noncurrent\_version\_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
 | noncurrent\_version\_transitions | Non-current version transition blocks | `list(any)` | ```[ { "days": 30, "storage_class": "STANDARD_IA" } ]``` | no |
 | object\_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
+| s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `null` | no |
 | schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
 | tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ No modules.
 | additional\_lifecycle\_rules | List of additional lifecycle rules to specify | `list(any)` | `[]` | no |
 | bucket | The name of the bucket. | `string` | n/a | yes |
 | bucket\_key\_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
-| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `false` | no |
+| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `true` | no |
 | cors\_rules | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
 | custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
 | enable\_analytics | Enables storage class analytics on the bucket. | `bool` | `true` | no |
@@ -106,7 +106,6 @@ No modules.
 | noncurrent\_version\_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
 | noncurrent\_version\_transitions | Non-current version transition blocks | `list(any)` | ```[ { "days": 30, "storage_class": "STANDARD_IA" } ]``` | no |
 | object\_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
-| s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `null` | no |
 | schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
 | tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
@@ -136,7 +135,7 @@ Version 5.x.x updates the module to account for changes made by AWS in April
 AWS automatically enables S3 Block Public Access and disables S3 access control
 lists for new S3 buckets.
 
-Version 5.x.x of this module adds a new resource and three new variables. How to
+Version 5.x.x of this module adds a new resource and two new variables. How to
 use the new variables will depend on your use case.
 
 New resource:
@@ -147,32 +146,17 @@ New variables:
 
 - `control_object_ownership`
 - `object_ownership`
-- `s3_bucket_acl`
 
-Steps for updating **existing buckets** managed by this module:
+Steps for updating existing buckets managed by this module:
 
-- Option 1: Use new AWS recommended defaults.
+- **Option 1: Disable ACLs (recommended).** In order to update an existing
+  bucket to use the new AWS recommended defaults, use this module's default
+  values for the new input variables. Using those settings will disable S3
+  access control lists for the bucket and set object ownership to
+  `BucketOwnerEnforced`.
 
-In order to update an existing bucket to use the new AWS recommended defaults,
-set the following input variable value:
-
-```text
-control_object_ownership = true
-```
-
-The above will disable S3 access control lists for the bucket and set object
-ownership to `BucketOwnerEnforced`.
-
-- Option 2: Preserve existing bucket configuration as-is.
-
-To preserve an existing bucket's configuration as-is, set the following input
-variable values:
-
-```text
-control_object_ownership = true
-object_ownership         = "ObjectWriter"
-s3_bucket_acl            = "private"
-```
+- **Option 2: Continue using ACLs.** To continue using ACLs, set
+  `object_ownership` to `ObjectWriter` or `BucketOwnerPreferred`.
 
 ### Upgrading from 3.x.x to 4.x.x
 

--- a/README.md
+++ b/README.md
@@ -132,11 +132,9 @@ No modules.
 ### Upgrading from 4.x.x to 5.x.x
 
 Version 5.x.x updates the module to account for changes made by AWS in April
-2023 to the default security settings of new S3 buckets. With the new changes,
-AWS automatically enables S3 Block Public Access and disables S3 access control
-lists for new S3 buckets.
+2023 to the default security settings of new S3 buckets.
 
-Version 5.x.x of this module adds a new resource and two new variables. How to
+Version 5.x.x of this module adds the following resource and variables. How to
 use the new variables will depend on your use case.
 
 New resource:
@@ -147,6 +145,7 @@ New variables:
 
 - `control_object_ownership`
 - `object_ownership`
+- `s3_bucket_acl`
 
 Steps for updating existing buckets managed by this module:
 
@@ -158,6 +157,10 @@ Steps for updating existing buckets managed by this module:
 
 - **Option 2: Continue using ACLs.** To continue using ACLs, set
   `object_ownership` to `ObjectWriter` or `BucketOwnerPreferred`.
+
+See [Controlling ownership of objects and disabling ACLs for your
+bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)
+for further details and migration considerations.
 
 ### Upgrading from 3.x.x to 4.x.x
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,10 @@ New variables:
 
 Steps for updating existing buckets managed by this module:
 
-- **Option 1: Disable ACLs (recommended).** In order to update an existing
-  bucket to use the new AWS recommended defaults, use this module's default
-  values for the new input variables. Using those settings will disable S3
-  access control lists for the bucket and set object ownership to
-  `BucketOwnerEnforced`.
+- **Option 1: Disable ACLs.** In order to update an existing bucket to use the
+  new AWS recommended defaults, use this module's default values for the new
+  input variables. Using those settings will disable S3 access control lists for
+  the bucket and set object ownership to `BucketOwnerEnforced`.
 
 - **Option 2: Continue using ACLs.** To continue using ACLs, set
   `object_ownership` to `ObjectWriter` or `BucketOwnerPreferred`.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,56 @@ No modules.
 
 ## Upgrade Paths
 
+### Upgrading from 4.x.x to 5.x.x
+
+Version 5.x.x updates the module to account for changes made by AWS in April
+2023 to the default security settings of new S3 buckets. With the new changes,
+AWS automatically enables S3 Block Public Access and disables S3 access control
+lists for new S3 buckets.
+
+Version 5.x.x of this module adds a new resource and three new variables. How to
+use the new variables will depend on your use case.
+
+New resource:
+
+- `aws_s3_bucket_ownership_controls.private_bucket`
+
+New variables:
+
+- `control_object_ownership`
+- `object_ownership`
+- `s3_bucket_acl`
+
+Using the module's default values will not create the
+`aws_s3_bucket_ownership_controls.private_bucket` or
+`aws_s3_bucket_acl.private_bucket` resources and will instead use the AWS
+defaults for the configurations managed by those resources.
+
+Steps for updating existing buckets managed by this module:
+
+- Option 1: Use new AWS recommended defaults.
+
+In order to update an existing bucket to use the new AWS recommended defaults,
+set the following input variable value:
+
+```text
+control_object_ownership = true
+```
+
+This will disable S3 access control lists for the bucket and set object
+ownership to `BucketOwnerEnforced`.
+
+- Option 2: Preserve existing bucket configuration as-is.
+
+To preserve an existing bucket's configuration as-is, set the following input
+variable values:
+
+```text
+control_object_ownership = true
+object_ownership         = "ObjectWriter"
+s3_bucket_acl            = "private"
+```
+
 ### Upgrading from 3.x.x to 4.x.x
 
 Version 4.x.x enables the use of version 4 of the AWS provider. Terraform provided [an upgrade path](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade) for this. To support the upgrade path, this module now includes the following additional resources:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ No modules.
 | [aws_s3_bucket_inventory.inventory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_inventory) | resource |
 | [aws_s3_bucket_lifecycle_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_ownership_controls.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.private_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
@@ -91,6 +92,7 @@ No modules.
 | additional\_lifecycle\_rules | List of additional lifecycle rules to specify | `list(any)` | `[]` | no |
 | bucket | The name of the bucket. | `string` | n/a | yes |
 | bucket\_key\_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
+| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `false` | no |
 | cors\_rules | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
 | custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
 | enable\_analytics | Enables storage class analytics on the bucket. | `bool` | `true` | no |
@@ -103,6 +105,7 @@ No modules.
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
 | noncurrent\_version\_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
 | noncurrent\_version\_transitions | Non-current version transition blocks | `list(any)` | ```[ { "days": 30, "storage_class": "STANDARD_IA" } ]``` | no |
+| object\_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
 | schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
 | tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "aws_s3_bucket_accelerate_configuration" "private_bucket" {
 
 resource "aws_s3_bucket_acl" "private_bucket" {
   bucket     = aws_s3_bucket.private_bucket.id
-  acl        = "private"
+  acl        = var.s3_bucket_acl
   depends_on = [aws_s3_bucket_ownership_controls.private_bucket]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_s3_bucket_accelerate_configuration" "private_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "private_bucket" {
-  cout       = var.s3_bucket_acl != null ? 1 : 0
+  count      = var.s3_bucket_acl != null ? 1 : 0
   bucket     = aws_s3_bucket.private_bucket.id
   acl        = var.s3_bucket_acl
   depends_on = [aws_s3_bucket_ownership_controls.private_bucket]

--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,8 @@ resource "aws_s3_bucket_acl" "private_bucket" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "private_bucket" {
+  count = var.control_object_ownership ? 1 : 0
+
   bucket = aws_s3_bucket.private_bucket.id
 
   rule {

--- a/main.tf
+++ b/main.tf
@@ -138,15 +138,12 @@ resource "aws_s3_bucket_accelerate_configuration" "private_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "private_bucket" {
-  count      = var.s3_bucket_acl != null ? 1 : 0
   bucket     = aws_s3_bucket.private_bucket.id
-  acl        = var.s3_bucket_acl
+  acl        = "private"
   depends_on = [aws_s3_bucket_ownership_controls.private_bucket]
 }
 
 resource "aws_s3_bucket_ownership_controls" "private_bucket" {
-  count = var.control_object_ownership ? 1 : 0
-
   bucket = aws_s3_bucket.private_bucket.id
 
   rule {

--- a/main.tf
+++ b/main.tf
@@ -138,8 +138,25 @@ resource "aws_s3_bucket_accelerate_configuration" "private_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "private_bucket" {
+  bucket     = aws_s3_bucket.private_bucket.id
+  acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.private_bucket]
+}
+
+resource "aws_s3_bucket_ownership_controls" "private_bucket" {
+  count = var.control_object_ownership ? 1 : 0
+
   bucket = aws_s3_bucket.private_bucket.id
-  acl    = "private"
+
+  rule {
+    object_ownership = var.object_ownership
+  }
+
+  depends_on = [
+    aws_s3_bucket_policy.private_bucket,
+    aws_s3_bucket_public_access_block.public_access_block,
+    aws_s3_bucket.private_bucket
+  ]
 }
 
 resource "aws_s3_bucket_versioning" "private_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,7 @@ resource "aws_s3_bucket_accelerate_configuration" "private_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "private_bucket" {
+  count      = var.s3_bucket_acl != null ? 1 : 0
   bucket     = aws_s3_bucket.private_bucket.id
   acl        = var.s3_bucket_acl
   depends_on = [aws_s3_bucket_ownership_controls.private_bucket]

--- a/main.tf
+++ b/main.tf
@@ -138,8 +138,9 @@ resource "aws_s3_bucket_accelerate_configuration" "private_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "private_bucket" {
+  cout       = var.s3_bucket_acl != null ? 1 : 0
   bucket     = aws_s3_bucket.private_bucket.id
-  acl        = "private"
+  acl        = var.s3_bucket_acl
   depends_on = [aws_s3_bucket_ownership_controls.private_bucket]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -157,17 +157,11 @@ variable "additional_lifecycle_rules" {
 variable "control_object_ownership" {
   description = "Whether to manage S3 Bucket Ownership Controls on this bucket."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "object_ownership" {
   description = "Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter."
   type        = string
   default     = "BucketOwnerEnforced"
-}
-
-variable "s3_bucket_acl" {
-  description = "Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list."
-  default     = null
-  type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -165,3 +165,9 @@ variable "object_ownership" {
   type        = string
   default     = "BucketOwnerEnforced"
 }
+
+variable "s3_bucket_acl" {
+  description = "Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list."
+  default     = null
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,15 @@ variable "additional_lifecycle_rules" {
   type        = list(any)
   default     = []
 }
+
+variable "control_object_ownership" {
+  description = "Whether to manage S3 Bucket Ownership Controls on this bucket."
+  type        = bool
+  default     = false
+}
+
+variable "object_ownership" {
+  description = "Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter."
+  type        = string
+  default     = "BucketOwnerEnforced"
+}


### PR DESCRIPTION
Updates the module to account for changes made by AWS in April 2023 to the default security settings of new S3 buckets.

https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

See the proposed changes in the README `Upgrade Paths` section for more details about the module changes.

If approved, the plan is to release this as a major version update.