### PR TITLE
Set sse_algorithm based on presence of kms_master_key_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,11 @@ No modules.
 | enable\_s3\_public\_access\_block | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
 | expiration | expiration blocks | `list(any)` | ```[ { "expired_object_delete_marker": true } ]``` | no |
 | inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
-| kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `""` | no |
+| kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. If blank, bucket encryption configuration defaults to AES256. | `string` | `""` | no |
 | logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
 | noncurrent\_version\_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
 | noncurrent\_version\_transitions | Non-current version transition blocks | `list(any)` | ```[ { "days": 30, "storage_class": "STANDARD_IA" } ]``` | no |
 | schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
-| sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
 | tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | transfer\_acceleration | Whether or not to enable bucket acceleration. | `bool` | `null` | no |
 | transitions | Current version transition blocks | `list(any)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "private_bucket" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm     = var.sse_algorithm
+      sse_algorithm     = length(var.kms_master_key_id) > 0 ? "aws:kms" : "AES256"
       kms_master_key_id = length(var.kms_master_key_id) > 0 ? var.kms_master_key_id : null
     }
     bucket_key_enabled = var.bucket_key_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -118,14 +118,8 @@ variable "noncurrent_version_expiration" {
   default     = 365
 }
 
-variable "sse_algorithm" {
-  description = "The server-side encryption algorithm to use. Valid values are AES256 and aws:kms"
-  type        = string
-  default     = "AES256"
-}
-
 variable "kms_master_key_id" {
-  description = "The AWS KMS master key ID used for the SSE-KMS encryption."
+  description = "The AWS KMS master key ID used for the SSE-KMS encryption. If blank, bucket encryption configuration defaults to AES256."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## 🔒 [Add validation on S3 bucket encryption configuration](https://trello.com/c/2CZ89HL1/291-review-terraform-pull-request-add-validation-on-s3-bucket-encryption-configuration)

Changes proposed in this pull request:

- Set bucket encryption configuration based on whether the KMS key id was passed as an argument. If not, default the encryption configuration to AES256.

Fixes #399
