### PR TITLE
Remove deprecated attributes from s3 bucket ignore_changes block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,19 +95,11 @@ resource "aws_s3_bucket" "private_bucket" {
     # path from version 3.x of the AWS provider to version 4.x
     ignore_changes = [
       # While no special usage instructions are documented for needing this
-      # ignore_changes rule, changes are still detected during the upgrade
-      # process, so this serves to avoid drift detection since the
-      # aws_s3_bucket_policy will be used instead.
-      policy,
-
-      # While no special usage instructions are documented for needing this
       # ignore_changes rule, this should avoid drift detection if conflicts
       # with the aws_s3_bucket_versioning exist.
       versioning,
 
       # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.2/docs/resources/s3_bucket_acl#usage-notes
-      acceleration_status,
-      acl,
       grant,
 
       # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.2/docs/resources/s3_bucket_cors_configuration#usage-notes


### PR DESCRIPTION
title, removes these warnings after terraform plan/apply:

```
╷
│ Warning: Deprecated attribute
│
│   on .terraform/modules/lambda_builds_us_gov_west_1/main.tf line 101, in resource "aws_s3_bucket" "private_bucket":
│  101:       policy,
│
│ The attribute "policy" is deprecated. Refer to the provider documentation for
│ details.
│
│ (and 5 more similar warnings elsewhere)
╵
```