### PR TITLE
Fix `use_account_alias_prefix` type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "use_random_suffix" {
 
 variable "use_account_alias_prefix" {
   description = "Whether to prefix the bucket name with the AWS account alias."
-  type        = string
+  type        = bool
   default     = true
 }
 


### PR DESCRIPTION
Fix `use_account_alias_prefix` type. Is a boolean instead of a string. Introduced by #10.
