### PR TITLE
fix: use proper parameters for some s3 bucket resources

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   validate-tf:
-    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main
+    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@3cab03ab95045711da37ad6d63a93c666fc22398 # v0.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .terraform
+.terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfstate.*.backup
+.envrc*

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -4,5 +4,6 @@
   "first-line-h1": false,
   "line_length": false,
   "no-multiple-blanks": false,
-  "no-inline-html": false
+  "no-inline-html": false,
+  "no-alt-text": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -14,27 +14,17 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
 
-  - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
-    hooks:
-      - id: mdformat
-        additional_dependencies:
-          - mdformat-gfm
-          - mdformat-toc
-        # mdformat fights with terraform_docs
-        exclude: README.m(ark)?d(own)?
-
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
 
-  - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.5
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: "v0.19.0"
     hooks:
-      - id: shell-lint
+      - id: terraform-docs-system
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.96.3
     hooks:
       - id: terraform_fmt

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,4 +1,35 @@
+version: ">= 0.19.0, < 1.0.0"
+
 settings:
   html: false
   anchor: false
+  escape: false
+  lockfile: false
+  hide-empty: true
 formatter: "markdown table"
+
+sort:
+  enabled: true
+  by: required
+
+sections:
+  show:
+    - requirements
+    - providers
+    - modules
+    - data-sources
+    - resources
+    - inputs
+    - outputs
+
+recursive:
+  enabled: false
+  include-main: false
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -45,17 +45,13 @@ module "aws-s3-bucket" {
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 3.75.0 |
+| aws | >= 5.43.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.75.0 |
-
-## Modules
-
-No modules.
+| aws | >= 5.43.0 |
 
 ## Resources
 
@@ -83,40 +79,41 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| abort\_incomplete\_multipart\_upload\_days | Number of days until aborting incomplete multipart uploads | `number` | `14` | no |
-| additional\_lifecycle\_rules | List of additional lifecycle rules to specify | `list(any)` | `[]` | no |
 | bucket | The name of the bucket. | `string` | n/a | yes |
-| bucket\_key\_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
-| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `true` | no |
-| cors\_rules | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
-| custom\_bucket\_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
-| enable\_analytics | Enables storage class analytics on the bucket. | `bool` | `true` | no |
-| enable\_bucket\_force\_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
-| enable\_bucket\_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
-| enable\_s3\_public\_access\_block | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
+| abort_incomplete_multipart_upload_days | Number of days until aborting incomplete multipart uploads | `number` | `14` | no |
+| additional_lifecycle_rules | List of additional lifecycle rules to specify | `list(any)` | `[]` | no |
+| bucket_key_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
+| control_object_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `true` | no |
+| cors_rules | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
+| custom_bucket_policy | JSON formatted bucket policy to attach to the bucket. | `string` | `""` | no |
+| enable_analytics | Enables storage class analytics on the bucket. | `bool` | `true` | no |
+| enable_bucket_force_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
+| enable_bucket_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
+| enable_s3_public_access_block | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
 | expiration | expiration blocks | `list(any)` | ```[ { "expired_object_delete_marker": true } ]``` | no |
-| inventory\_bucket\_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
-| kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. If blank, bucket encryption configuration defaults to AES256. | `string` | `""` | no |
-| logging\_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
-| noncurrent\_version\_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
-| noncurrent\_version\_transitions | Non-current version transition blocks | `list(any)` | ```[ { "days": 30, "storage_class": "STANDARD_IA" } ]``` | no |
-| object\_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
-| s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `null` | no |
-| schedule\_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
+| inventory_bucket_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
+| kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption. If blank, bucket encryption configuration defaults to AES256. | `string` | `""` | no |
+| logging_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
+| noncurrent_version_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
+| noncurrent_version_transitions | Non-current version transition blocks | `list(any)` | ```[ { "days": 30, "storage_class": "STANDARD_IA" } ]``` | no |
+| object_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
+| s3_bucket_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `null` | no |
+| schedule_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
 | tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
-| transfer\_acceleration | Whether or not to enable bucket acceleration. | `bool` | `null` | no |
+| transfer_acceleration | Whether or not to enable bucket acceleration. | `bool` | `null` | no |
 | transitions | Current version transition blocks | `list(any)` | `[]` | no |
-| use\_account\_alias\_prefix | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |
-| use\_random\_suffix | Whether to add a random suffix to the bucket name. | `bool` | `false` | no |
-| versioning\_status | A string that indicates the versioning status for the log bucket. | `string` | `"Enabled"` | no |
+| use_account_alias_prefix | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |
+| use_random_suffix | Whether to add a random suffix to the bucket name. | `bool` | `false` | no |
+| versioning_status | A string that indicates the versioning status for the log bucket. | `string` | `"Enabled"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | arn | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
-| bucket\_domain\_name | The bucket domain name. |
-| bucket\_regional\_domain\_name | The bucket region-specific domain name. |
+| bucket_domain_name | The bucket domain name. |
+| bucket_logging_prefix | Prefix defined for logging to an S3 bucket. |
+| bucket_regional_domain_name | The bucket region-specific domain name. |
 | id | The name of the bucket. |
 | name | The Name of the bucket. Will be of format bucketprefix-bucketname. |
 <!-- END_TF_DOCS -->

--- a/examples/bucket-inventory/main.tf
+++ b/examples/bucket-inventory/main.tf
@@ -26,5 +26,7 @@ module "s3_logs" {
 
   s3_bucket_name = var.logging_bucket
 
-  default_allow = false
+  default_allow  = false
+  allow_s3       = true
+  s3_logs_prefix = ["s3/${module.s3_private_bucket.bucket}"]
 }

--- a/examples/bucket-inventory/main.tf
+++ b/examples/bucket-inventory/main.tf
@@ -28,5 +28,5 @@ module "s3_logs" {
 
   default_allow  = false
   allow_s3       = true
-  s3_logs_prefix = ["s3/${module.s3_private_bucket.bucket}"]
+  s3_logs_prefix = ["s3/${var.test_name}"]
 }

--- a/examples/custom-bucket-policy/main.tf
+++ b/examples/custom-bucket-policy/main.tf
@@ -57,4 +57,7 @@ module "s3_logs" {
   s3_bucket_name = var.logging_bucket
 
   default_allow = false
+  allow_s3      = true
+
+  s3_logs_prefix = ["s3/${module.s3_private_bucket.bucket}"]
 }

--- a/examples/custom-bucket-policy/main.tf
+++ b/examples/custom-bucket-policy/main.tf
@@ -59,5 +59,5 @@ module "s3_logs" {
   default_allow = false
   allow_s3      = true
 
-  s3_logs_prefix = ["s3/${module.s3_private_bucket.bucket}"]
+  s3_logs_prefix = ["s3/${var.test_name}"]
 }

--- a/examples/s3-bucket-key/main.tf
+++ b/examples/s3-bucket-key/main.tf
@@ -19,6 +19,5 @@ module "s3_private_bucket" {
   use_account_alias_prefix = false
 
   kms_master_key_id  = module.aws_s3_bucket_kms_key.aws_kms_key_arn
-  sse_algorithm      = "aws:kms"
   bucket_key_enabled = true
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -28,4 +28,7 @@ module "s3_logs" {
   s3_bucket_name = var.logging_bucket
 
   default_allow = false
+  allow_s3      = true
+
+  s3_logs_prefix = ["s3/${module.s3_private_bucket.bucket}"]
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -30,5 +30,5 @@ module "s3_logs" {
   default_allow = false
   allow_s3      = true
 
-  s3_logs_prefix = ["s3/${module.s3_private_bucket.bucket}"]
+  s3_logs_prefix = ["s3/${var.test_name}"]
 }

--- a/main.tf
+++ b/main.tf
@@ -12,16 +12,7 @@ locals {
 }
 
 data "aws_iam_policy_document" "supplemental_policy" {
-  # This should be a single line:
-  # source_policy_documents = [var.custom_bucket_policy]
-  #
-  # However, there appears to be a bug that occurs when source_policy_documents is an empty string:
-  # - https://github.com/hashicorp/terraform-provider-aws/issues/22959
-  # - https://github.com/hashicorp/terraform-provider-aws/issues/24366
-  #
-  # To work around this, we're using this workaround. It should be replaced
-  # once the underlying issue is addressed.
-  source_policy_documents = length(var.custom_bucket_policy) > 0 ? [var.custom_bucket_policy] : null
+  source_policy_documents = [var.custom_bucket_policy]
 
   # Enforce SSL/TLS on all transmitted objects
   # We do this by extending the custom_bucket_policy
@@ -276,7 +267,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "private_bucket" {
 resource "aws_s3_bucket_cors_configuration" "private_bucket" {
   count = length(var.cors_rules)
 
-  bucket = aws_s3_bucket.private_bucket.bucket
+  bucket = aws_s3_bucket.private_bucket.id
 
   cors_rule {
     allowed_methods = var.cors_rules[count.index].allowed_methods
@@ -290,7 +281,7 @@ resource "aws_s3_bucket_cors_configuration" "private_bucket" {
 resource "aws_s3_bucket_analytics_configuration" "private_analytics_config" {
   count = var.enable_analytics ? 1 : 0
 
-  bucket = aws_s3_bucket.private_bucket.bucket
+  bucket = aws_s3_bucket.private_bucket.id
   name   = "Analytics"
 
   storage_class_analysis {

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "bucket_regional_domain_name" {
   description = "The bucket region-specific domain name."
   value       = aws_s3_bucket.private_bucket.bucket_regional_domain_name
 }
+
+output "bucket_logging_prefix" {
+  description = "Prefix defined for logging to an S3 bucket."
+  value       = aws_s3_bucket_logging.private_bucket.target_prefix
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
   "labels": [
@@ -30,7 +30,7 @@
       "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
-      "managers": [
+      "matchManagers": [
         "terraform",
         "pre-commit",
         "github-actions"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":disableDependencyDashboard"
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": [
     "dependencies"
@@ -33,7 +33,6 @@
       "managers": [
         "terraform",
         "pre-commit",
-        "dockerfile",
         "github-actions"
       ],
       "matchUpdateTypes": [

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    aws = ">= 3.75.0"
+    aws = ">= 5.43.0"
   }
 }


### PR DESCRIPTION
- **chore: override_policy_document and source_policy_document fixed in this release**
- **chore: renovate renovate config**
- **chore: output the target prefix allowing it to be used in terraform-aws-logs**
- **docs: examples are more accurate**
- **chore: pinning shared action**
- **chore: block tf lock file**
- **chore: pre-commit autoupdate**
- **chore: use valid parameter and get rid of workaround for source_policy_document and override_policy_document**
- **docs: terraform_docs**

[TF Issue 24366](https://github.com/hashicorp/terraform-provider-aws/issues/24366)
[TF Issue 22959](https://github.com/hashicorp/terraform-provider-aws/issues/22959)
