### PR TITLE
fix: aws_s3_bucket_logging.private_bucket has 'count' set

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -25,5 +25,5 @@ output "bucket_regional_domain_name" {
 
 output "bucket_logging_prefix" {
   description = "Prefix defined for logging to an S3 bucket."
-  value       = aws_s3_bucket_logging.private_bucket.target_prefix
+  value       = aws_s3_bucket_logging.private_bucket[*].target_prefix
 }


### PR DESCRIPTION
`aws_s3_logging_bucket.private_bucket` has `count` set which requires an indexed attribute.
