### PR TITLE
fix: Update module default lifecycle rules to work better with AWS Provider 5.89+

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ module "aws-s3-bucket" {
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 5.43.0 |
+| aws | >= 5.89.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 5.43.0 |
+| aws | >= 5.89.0 |
 
 ## Resources
 
@@ -90,19 +90,19 @@ module "aws-s3-bucket" {
 | enable_bucket_force_destroy | If set to true, Bucket will be emptied and destroyed when terraform destroy is run. | `bool` | `false` | no |
 | enable_bucket_inventory | If set to true, Bucket Inventory will be enabled. | `bool` | `false` | no |
 | enable_s3_public_access_block | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
-| expiration | expiration blocks | `list(any)` | ```[ { "expired_object_delete_marker": true } ]``` | no |
 | inventory_bucket_format | The format for the inventory file. Default is ORC. Options are ORC or CSV. | `string` | `"ORC"` | no |
 | kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption. If blank, bucket encryption configuration defaults to AES256. | `string` | `""` | no |
+| lifecycle_abort_incomplete_upload | Default values for the abort incomplete mutlipart uploads lifecycle rule | `map` | ```{ "expiration": { "date": null, "days": null, "expired_object_delete_marker": true }, "nve": { "newer_noncurrent_versions": null, "noncurrent_days": 365 }, "nvt": { "newer_noncurrent_versions": null, "noncurrent_days": 30, "storage_class": "STANDARD_IA" }, "transition": null }``` | no |
+| lifecycle_aws_bucket_analytics_expiration | Number of days to keep aws bucket analytics objects | `number` | `30` | no |
+| lifecycle_aws_bucket_inventory_expiration | Number of days unused items expire from AWS Inventory | `number` | `14` | no |
 | logging_bucket | The S3 bucket to send S3 access logs. | `string` | `""` | no |
-| noncurrent_version_expiration | Number of days until non-current version of object expires | `number` | `365` | no |
-| noncurrent_version_transitions | Non-current version transition blocks | `list(any)` | ```[ { "days": 30, "storage_class": "STANDARD_IA" } ]``` | no |
 | object_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
 | s3_bucket_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `null` | no |
 | schedule_frequency | The S3 bucket inventory frequency. Defaults to Weekly. Options are 'Weekly' or 'Daily'. | `string` | `"Weekly"` | no |
 | tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | transfer_acceleration | Whether or not to enable bucket acceleration. | `bool` | `null` | no |
-| transitions | Current version transition blocks | `list(any)` | `[]` | no |
-| use_account_alias_prefix | Whether to prefix the bucket name with the AWS account alias. | `string` | `true` | no |
+| transition_default_minimum_object_size | Minimum object size to transition for lifecycle rule | `string` | `"all_storage_classes_128K"` | no |
+| use_account_alias_prefix | Whether to prefix the bucket name with the AWS account alias. | `bool` | `true` | no |
 | use_random_suffix | Whether to add a random suffix to the bucket name. | `bool` | `false` | no |
 | versioning_status | A string that indicates the versioning status for the log bucket. | `string` | `"Enabled"` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
 
   # Detect aspects of default lifecycle rules
   aiu_has_expiration = var.lifecycle_abort_incomplete_upload.expiration != null ? true : false
-  aiu_has_transition = var.lifecycle_abort_incomplete_upload.transition != null ? false : true
+  aiu_has_transition = var.lifecycle_abort_incomplete_upload.transition != null ? true : false
   aiu_has_nvt        = var.lifecycle_abort_incomplete_upload.nvt != null ? true : false
   aiu_has_nve        = var.lifecycle_abort_incomplete_upload.nve != null ? true : false
 

--- a/main.tf
+++ b/main.tf
@@ -13,8 +13,8 @@ locals {
   # Detect aspects of default lifecycle rules
   aiu_has_expiration = var.lifecycle_abort_incomplete_upload.expiration != null ? true : false
   aiu_has_transition = var.lifecycle_abort_incomplete_upload.transition != null ? false : true
-  aiu_has_nvt = var.lifecycle_abort_incomplete_upload.nvt != null ? true : false
-  aiu_has_nve = var.lifecycle_abort_incomplete_upload.nve != null ? true : false
+  aiu_has_nvt        = var.lifecycle_abort_incomplete_upload.nvt != null ? true : false
+  aiu_has_nve        = var.lifecycle_abort_incomplete_upload.nve != null ? true : false
 
 }
 
@@ -159,7 +159,7 @@ resource "aws_s3_bucket_versioning" "private_bucket" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
-  bucket = aws_s3_bucket.private_bucket.id
+  bucket                                 = aws_s3_bucket.private_bucket.id
   transition_default_minimum_object_size = var.transition_default_minimum_object_size
 
   rule {
@@ -174,8 +174,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
     dynamic "expiration" {
       for_each = local.aiu_has_expiration == true ? [var.lifecycle_abort_incomplete_upload.expiration] : []
       content {
-        date = expiration.value.date
-        days = expiration.value.days
+        date                         = expiration.value.date
+        days                         = expiration.value.days
         expired_object_delete_marker = expiration.value.expired_object_delete_marker
       }
     }
@@ -183,7 +183,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
     dynamic "transition" {
       for_each = local.aiu_has_transition == true ? [var.lifecycle_abort_incomplete_upload.transition] : []
       content {
-        days = transition.value.days
+        days          = transition.value.days
         storage_class = transition.value.storage_class
       }
     }
@@ -192,8 +192,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
       for_each = local.aiu_has_nvt == true ? [var.lifecycle_abort_incomplete_upload.nvt] : []
       content {
         newer_noncurrent_versions = noncurrent_version_transition.value.newer_noncurrent_versions
-        noncurrent_days = noncurrent_version_transition.value.noncurrent_days
-        storage_class = noncurrent_version_transition.value.storage_class
+        noncurrent_days           = noncurrent_version_transition.value.noncurrent_days
+        storage_class             = noncurrent_version_transition.value.storage_class
       }
     }
 
@@ -201,7 +201,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
       for_each = local.aiu_has_nve == true ? [var.lifecycle_abort_incomplete_upload.nve] : []
       content {
         newer_noncurrent_versions = noncurrent_version_expiration.value.newer_noncurrent_versions
-        noncurrent_days = noncurrent_version_expiration.value.noncurrent_days
+        noncurrent_days           = noncurrent_version_expiration.value.noncurrent_days
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -63,16 +63,6 @@ variable "enable_s3_public_access_block" {
   default     = true
 }
 
-variable "expiration" {
-  description = "expiration blocks"
-  type        = list(any)
-  default = [
-    {
-      expired_object_delete_marker = true
-    }
-  ]
-}
-
 variable "inventory_bucket_format" {
   type        = string
   default     = "ORC"
@@ -85,27 +75,49 @@ variable "kms_master_key_id" {
   default     = ""
 }
 
+variable "lifecycle_abort_incomplete_upload" {
+  description = "Default values for the abort incomplete mutlipart uploads lifecycle rule"
+  default = {
+    expiration = {
+      expired_object_delete_marker = true
+      days = null
+      date = null
+    }
+    # No transition block necessary by default
+    transition = null
+
+    # noncurrent_version_transition (nvt) block attributes
+    nvt = {
+      newer_noncurrent_versions = null
+      noncurrent_days = 30
+      storage_class = "STANDARD_IA"
+    }
+    
+    # noncurrent_version_expiration (nve) block attributes
+    # Number of days until non-current version of object expires
+    nve = {
+      newer_noncurrent_versions = null,
+      noncurrent_days = 365
+    }
+  }
+}
+
+variable lifecycle_aws_bucket_analytics_expiration {
+  description = "Number of days to keep aws bucket analytics objects"
+  type = number
+  default = 30
+}
+
+variable "lifecycle_aws_bucket_inventory_expiration" {
+  description = "Number of days unused items expire from AWS Inventory"
+  type = number
+  default = 14
+}
+
 variable "logging_bucket" {
   description = "The S3 bucket to send S3 access logs."
   type        = string
   default     = ""
-}
-
-variable "noncurrent_version_expiration" {
-  description = "Number of days until non-current version of object expires"
-  type        = number
-  default     = 365
-}
-
-variable "noncurrent_version_transitions" {
-  description = "Non-current version transition blocks"
-  type        = list(any)
-  default = [
-    {
-      days          = 30
-      storage_class = "STANDARD_IA"
-    }
-  ]
 }
 
 variable "object_ownership" {
@@ -138,10 +150,16 @@ variable "transfer_acceleration" {
   default     = null
 }
 
-variable "transitions" {
-  description = "Current version transition blocks"
-  type        = list(any)
-  default     = []
+# variable "transitions" {
+#   description = "Current version transition blocks"
+#   type        = list(any)
+#   default     = []
+# }
+
+variable "transition_default_minimum_object_size" {
+  description = "Minimum object size to transition for lifecycle rule"
+  type = string
+  default = "all_storage_classes_128K"
 }
 
 variable "use_account_alias_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -80,8 +80,8 @@ variable "lifecycle_abort_incomplete_upload" {
   default = {
     expiration = {
       expired_object_delete_marker = true
-      days = null
-      date = null
+      days                         = null
+      date                         = null
     }
     # No transition block necessary by default
     transition = null
@@ -89,29 +89,29 @@ variable "lifecycle_abort_incomplete_upload" {
     # noncurrent_version_transition (nvt) block attributes
     nvt = {
       newer_noncurrent_versions = null
-      noncurrent_days = 30
-      storage_class = "STANDARD_IA"
+      noncurrent_days           = 30
+      storage_class             = "STANDARD_IA"
     }
-    
+
     # noncurrent_version_expiration (nve) block attributes
     # Number of days until non-current version of object expires
     nve = {
       newer_noncurrent_versions = null,
-      noncurrent_days = 365
+      noncurrent_days           = 365
     }
   }
 }
 
-variable lifecycle_aws_bucket_analytics_expiration {
+variable "lifecycle_aws_bucket_analytics_expiration" {
   description = "Number of days to keep aws bucket analytics objects"
-  type = number
-  default = 30
+  type        = number
+  default     = 30
 }
 
 variable "lifecycle_aws_bucket_inventory_expiration" {
   description = "Number of days unused items expire from AWS Inventory"
-  type = number
-  default = 14
+  type        = number
+  default     = 14
 }
 
 variable "logging_bucket" {
@@ -158,8 +158,8 @@ variable "transfer_acceleration" {
 
 variable "transition_default_minimum_object_size" {
   description = "Minimum object size to transition for lifecycle rule"
-  type = string
-  default = "all_storage_classes_128K"
+  type        = string
+  default     = "all_storage_classes_128K"
 }
 
 variable "use_account_alias_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -150,12 +150,6 @@ variable "transfer_acceleration" {
   default     = null
 }
 
-# variable "transitions" {
-#   description = "Current version transition blocks"
-#   type        = list(any)
-#   default     = []
-# }
-
 variable "transition_default_minimum_object_size" {
   description = "Minimum object size to transition for lifecycle rule"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    aws = ">= 5.43.0"
+    aws = ">= 5.89.0"
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Makes it more clear how to provide a variable to override configuration of aborted, incomplete upload lifecycle rule
- Ensures that rule ^ has all the proper defaults and doesn't throw warnings drift with the provider upgrade
- Allows the analytics and inventory expiration days to be configured by the user as well as to enable/disable those rules if those elements are enabled/disabled rather than always being enabled.
- Made the minimum provider version 5.89 now, and will bump the module version.
