### PR TITLE
fix: add missing filter block to lifecycle configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - repo: https://github.com/terraform-docs/terraform-docs
     rev: "v0.19.0"
     hooks:
-      - id: terraform-docs-system
+      - id: terraform-docs-go
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.96.3

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
 
     status = "Enabled"
 
+    filter {}
+
     abort_incomplete_multipart_upload {
       days_after_initiation = var.abort_incomplete_multipart_upload_days
     }


### PR DESCRIPTION
## Fix AWS Provider Lifecycle Filter Warning

Changes proposed in this pull request:

- Add empty `filter {}` block to abort-incomplete-multipart-upload lifecycle rule
- Resolve AWS provider warning about missing filter/prefix attributes
- Maintain backward compatibility with existing deployments

## Error Being Fixed

```
│ Warning: Invalid Attribute Combination
│ 
│   with module.s3_project.aws_s3_bucket_lifecycle_configuration.private_bucket,
│   on .terraform/modules/s3_document_search/main.tf line 161, in resource "aws_s3_bucket_lifecycle_configuration" "private_bucket":
│  161: resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
│ 
│ No attribute specified when one (and only one) of
│ [rule[0].filter,rule[0].prefix] is required
│ 
│ This will be an error in a future version of the provider
```