### PR TITLE
fix: add filter to get rid of warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -159,6 +159,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
 
     status = "Enabled"
 
+    filter = {}
+    
     abort_incomplete_multipart_upload {
       days_after_initiation = var.abort_incomplete_multipart_upload_days
     }


### PR DESCRIPTION
This is built on the v8.0.2 release, not the latest (soon to be reverted) v8.0.3

This fixes the warning in the abort-incomplete-multipart-upload lifecycle rule by adding an empty filter to the code block. 

```
│ Warning: Invalid Attribute Combination
│ 
│   with module.s3_project.aws_s3_bucket_lifecycle_configuration.private_bucket,
│   on .terraform/modules/s3_document_search/main.tf line 161, in resource "aws_s3_bucket_lifecycle_configuration" "private_bucket":
│  161: resource "aws_s3_bucket_lifecycle_configuration" "private_bucket" {
│ 
│ No attribute specified when one (and only one) of
│ [rule[0].filter,rule[0].prefix] is required
│ 
│ This will be an error in a future version of the provider
```